### PR TITLE
Modify representation of verbatim blocks.

### DIFF
--- a/examples/distributed.toml
+++ b/examples/distributed.toml
@@ -1,0 +1,13 @@
+[distributed]
+logo = "../dask-logo.png"
+exclude = [
+    # VisitTarget not implemented
+    "distributed.comm.ucx",
+    # misc
+    "distributed.worker.Worker",
+    "distributed.client.get_task_stream",
+    "distributed.batched.BatchedSend",
+
+
+] #docs_path = "~/dev/dask/docs/source"
+exec_failure = 'fallback'

--- a/papyri/ascii.tpl.j2
+++ b/papyri/ascii.tpl.j2
@@ -76,9 +76,7 @@
    |   |{% elif type == 'Paragraph' %}
    |   |   |{{block_paragraph(obj)}}
    |   |{% elif type == 'BlockVerbatim' %}
-   |   |   |{%- for l in obj.lines -%}
-   |   |   |   |{{l._line}}{% if not loop.last %}{{-'\n'-}}{% endif %}
-   |   |   |{%- endfor -%}
+   |   |   |{{obj.value}}
    |   |{% elif type == 'Block' %}
    |   |   |   |   |{{unreachable()}}
    |   |{% elif type == 'DefList' %}

--- a/papyri/browser.py
+++ b/papyri/browser.py
@@ -418,10 +418,8 @@ class Renderer:
         return ("verbatim", verb.value)
 
     def render_BlockVerbatim(self, verb):
-        acc = []
-        for line in verb.lines:
-            acc.append(Text(line._line))
-        return urwid.Pile(acc)
+        acc = [Text(("verbatim", verb.value))]
+        return urwid.Padding(urwid.Pile(acc), left=4)
 
     def render_Paragraph(self, paragraph):
         from .take2 import Paragraph

--- a/papyri/gen.py
+++ b/papyri/gen.py
@@ -1411,7 +1411,8 @@ class Gen:
                     )
                 except Exception as e:
                     failure_collection["ErrorHelper1-" + str(type(e))].append(qa)
-                    continue
+                    raise
+                    # continue
 
                 try:
                     if item_docstring is None:

--- a/papyri/macros.tpl.j2
+++ b/papyri/macros.tpl.j2
@@ -119,9 +119,8 @@
         {{block_paragraph(obj)}}
        {% elif type == 'BlockVerbatim' %}
             <pre>
-           {%- for l in obj.lines.dedented() -%}
-{{-l.text}}{% if not loop.last %}{{-'\n'-}}{%- endif -%}
-           {%- endfor -%}</pre>
+           {{- obj.value -}}
+           </pre>
        {% elif type == 'Block' %}
            {{block(obj)}}
            {{unreachable(obj)}}

--- a/papyri/render.py
+++ b/papyri/render.py
@@ -43,9 +43,9 @@ def url(info, prefix="/p/"):
         assert info.version is None
         return info.path
     if info.kind == "examples":
-        return f"/{prefix}/{info.module}/{info.version}/examples/{info.path}"
+        return f"{prefix}{info.module}/{info.version}/examples/{info.path}"
     else:
-        return f"/{prefix}/{info.module}/{info.version}/api/{info.path}"
+        return f"{prefix}{info.module}/{info.version}/api/{info.path}"
 
 
 def unreachable(*obj):

--- a/papyri/take2.py
+++ b/papyri/take2.py
@@ -486,6 +486,9 @@ class Strong(Node):
     def __hash__(self):
         return hash(repr(self))
 
+    def is_whitespace(self):
+        return False
+
 
 class _XList(Node):
     value: List[
@@ -1147,23 +1150,22 @@ class Comment(Block):
 
 class BlockVerbatim(Block):
 
-    lines: Lines
+    value: str
 
-    def __init__(self, lines):
+    def __init__(self, value):
 
-        self.lines = lines
+        assert isinstance(value, str)
+        self.value = value
 
     def __eq__(self, other):
-        return (type(self) == type(other)) and (self.lines == other.lines)
+        return (type(self) == type(other)) and (self.value == other.value)
 
     @classmethod
     def _instance(cls):
         return cls("")
 
     def __repr__(self):
-        return f"<{self.__class__.__name__} '{len(self.lines)}'> with\n" + indent(
-            "\n".join([str(l) for l in self.lines]), "    "
-        )
+        return f"<{self.__class__.__name__} '{len(self.value)}'>"
 
     def to_json(self):
         return serialize(self, type(self))

--- a/papyri/ts.py
+++ b/papyri/ts.py
@@ -295,16 +295,16 @@ class TSVisitor:
 
     def visit_literal_block(self, node, prev_end=None):
         data = self.bytes[node.start_byte : node.end_byte].decode().splitlines()
-        ded = node.start_point[1]
+        dedent_amount = node.start_point[1]
+
+        # here we need to do a bit of custom logic to properly dedent
         acc = [data[0]]
         for x in data[1:]:
-            acc.append(x[ded:])
-        lines = Lines(acc)
-        if prev_end is not None:
-            for l in lines:
-                l._number += node.start_point[0] - prev_end[0]
+            # TODO : maybe assert here that what we remove is actually only whitespace ?
+            # should we have a blcok verbatim with the first node more indented than subsequent ones ?
+            acc.append(x[dedent_amount:])
 
-        b = BlockVerbatim(lines)
+        b = BlockVerbatim("\n".join(acc))
 
         # print(' '*self.depth*4, b)
         return [b]
@@ -397,12 +397,7 @@ class TSVisitor:
 
     def visit_doctest_block(self, node, prev_end=None) -> List[BlockVerbatim]:
         # TODO
-        # likely want to dispatch to the parse example routine.
-        return [
-            BlockVerbatim(
-                Lines(self.bytes[node.start_byte : node.end_byte].decode().splitlines())
-            )
-        ]
+        return self.visit_literal_block(node, prev_end)
 
     def visit_field(self, node, prev_end=None):
         return []

--- a/papyri/utils.py
+++ b/papyri/utils.py
@@ -81,7 +81,7 @@ def dedent_but_first(text):
     """
     simple version of `inspect.cleandoc` that does not trim empty lines
     """
-    assert isinstance(text, str)
+    assert isinstance(text, str), (text, type(text))
     a, *b = text.split("\n")
     return dedent(a) + "\n" + dedent("\n".join(b))
 


### PR DESCRIPTION
This simplify the verbatim blocks to only contain a string of the inner
content, which is simpler to render in many cases.

That is a change of IRD format so all IRD will need to be rebuild, but
as we are not yet in a stable phase, that is acceptable