### PR TITLE
MAINT: pass config to the gen object.

### DIFF
--- a/papyri/gen.py
+++ b/papyri/gen.py
@@ -491,9 +491,7 @@ def gen_main(
     if not target_dir.exists() and not dry_run:
         target_dir.mkdir(parents=True, exist_ok=True)
 
-    g = Gen(
-        dummy_progress=dummy_progress,
-    )
+    g = Gen(dummy_progress=dummy_progress, config=config)
     g.log.info("Will write data to %s", target_dir)
     if debug:
         g.log.setLevel("DEBUG")
@@ -811,7 +809,7 @@ class Gen:
 
     """
 
-    def __init__(self, dummy_progress):
+    def __init__(self, dummy_progress, config):
 
         if dummy_progress:
             self.Progress = DummyP

--- a/papyri/tests/test_gen.py
+++ b/papyri/tests/test_gen.py
@@ -13,12 +13,13 @@ def test_find_beyond_decorators():
 
     For example the lru_decorator.
     """
-    gen = Gen(dummy_progress=True)
+    config = Config(exec=True, infer=True)
+    gen = Gen(dummy_progress=True, config=config)
     doc, figs = gen.do_one_item(
         ex1,
         NumpyDocString(""),
         qa="irrelevant",
-        config=Config(exec=True, infer=True),
+        config=config,
         aliases=[],
     )
 


### PR DESCRIPTION
This will allow in a later refactor to not have to pass it
explicitly to all the methods one by one.