### PR TITLE
PR: Add new schema

### DIFF
--- a/papyri/graphstore.py
+++ b/papyri/graphstore.py
@@ -90,13 +90,31 @@ class GraphStore:
         p = p.expanduser()
         if not p.exists():
             self.conn = sqlite3.connect(str(p))
+            self.conn.execute("PRAGMA foreign_keys = 2")
+
             print("Creating documents table")
             self.conn.cursor().execute(
-                "CREATE TABLE documents(id, package, version, category, identifier)"
+                """
+                CREATE TABLE documents(
+                id INTEGER PRIMARY KEY,
+                package TEXT NOT NULL,
+                version TEXT NOT NULL,
+                category TEXT NOT NULL,
+                identifier NOT NULL)
+                """
             )
+
             print("Creating links table")
             self.conn.cursor().execute(
-                "CREATE TABLE links(source, dest, metadata)"
+                """
+                CREATE TABLE links(
+                id INTEGER PRIMARY KEY,
+                source INTEGER NOT NULL,
+                dest INTEGER NOT NULL,
+                metadata TEXT,
+                FOREIGN KEY (source) REFERENCES documents(id)
+                FOREIGN KEY (dest) REFERENCES documents(id))
+                """
             )
         else:
             self.conn = sqlite3.connect(str(p))

--- a/papyri/graphstore.py
+++ b/papyri/graphstore.py
@@ -90,7 +90,7 @@ class GraphStore:
         p = p.expanduser()
         if not p.exists():
             self.conn = sqlite3.connect(str(p))
-            self.conn.execute("PRAGMA foreign_keys = 2")
+            self.conn.execute("PRAGMA foreign_keys = 1")
 
             print("Creating documents table")
             self.conn.cursor().execute(
@@ -112,10 +112,12 @@ class GraphStore:
                 source INTEGER NOT NULL,
                 dest INTEGER NOT NULL,
                 metadata TEXT,
-                FOREIGN KEY (source) REFERENCES documents(id)
-                FOREIGN KEY (dest) REFERENCES documents(id))
+                FOREIGN KEY (source) REFERENCES documents(id) ON DELETE CASCADE
+                FOREIGN KEY (dest) REFERENCES documents(id) ON DELETE CASCADE)
                 """
             )
+
+            self.conn.commit()
         else:
             self.conn = sqlite3.connect(str(p))
 


### PR DESCRIPTION
This PR adds new schema to the papyri db,

- [x] Renames the connection to the database
- [x] Creates two tables, `documents` and `links` where the information will be stored
- [ ] Adds new logic to add new information to the `documents` table
- [ ] Fixes the current logic to create the entries for the `links` table
- [ ] Adds new logic to remove information from the `documents` table
- [ ] Fixes the current logic to remove the information from the `links` table

Fixes #86 