### PR TITLE
PR: Rename top level conf keys to avoid future import conflicts

### DIFF
--- a/examples/IPython.toml
+++ b/examples/IPython.toml
@@ -1,4 +1,5 @@
-[IPython]
+[global]
+module = 'IPython'
 logo = "../ipython-logo.png"
 exec_failure = "fallback"
 exec = true

--- a/examples/astropy.toml
+++ b/examples/astropy.toml
@@ -1,4 +1,5 @@
-[astropy]
+[global]
+module = 'astropy'
 logo = "astropy_project_logo.svg"
 exclude = ["astropy.utils.misc.OrderedDescriptorContainer",
 # VisitTargetNotImplementedError

--- a/examples/dask.toml
+++ b/examples/dask.toml
@@ -1,4 +1,5 @@
-[dask]
+[global]
+module = 'dask'
 logo = "../dask-logo.png"
 submodules = ["array"]
 exclude = [ "dask.utils.Dispatch",

--- a/examples/distributed.toml
+++ b/examples/distributed.toml
@@ -1,4 +1,5 @@
-[distributed]
+[global]
+module = 'distributed'
 logo = "../dask-logo.png"
 exclude = [
     # VisitTarget not implemented

--- a/examples/matplotlib.toml
+++ b/examples/matplotlib.toml
@@ -1,4 +1,5 @@
-[matplotlib]
+[global]
+module = 'matplotlib'
 logo = "../matplotlib_logo.png"
 wait_for_plt_show = false
 exec_failure = "fallback"
@@ -12,7 +13,7 @@ examples_exclude = [
 "load_converter.py",
 "date_index_formatter2.py",
 # all sphinx gallery skip...
-"sgskip.py", 
+"sgskip.py",
 # other
 "pathpatch3d.py",
 "units/artist_tests.py",
@@ -83,7 +84,7 @@ exec = true
 [matplotlib.expected_errors]
 VisitSubstitutionDefinitionNotImplementedError = [
     "matplotlib.markers",
-    ]                                                                        
+    ]
 IncorrectInternalDocsLen = [
     "matplotlib.rc",
     "matplotlib.pyplot.rc",
@@ -99,7 +100,7 @@ IncorrectInternalDocsLen = [
     "matplotlib.patches.ConnectionStyle._Base",
     "matplotlib.tri.triinterpolate._safe_inv22_vectorized",
     ]
-ValueError = [ 
+ValueError = [
     "matplotlib.image.thumbnail",
     "matplotlib.artist.Artist.set_sketch_params",
     "matplotlib.artist.Artist.set_agg_filter",

--- a/examples/networkx.toml
+++ b/examples/networkx.toml
@@ -1,4 +1,5 @@
-[networkx]
+[global]
+module = 'networkx'
 execute_exclude_patterns = []
 
 submodules = []

--- a/examples/numpy.toml
+++ b/examples/numpy.toml
@@ -1,4 +1,5 @@
-[numpy]
+[global]
+module = 'numpy'
 execute_exclude_patterns = ['numpy._','numpy.testing._priv', 'numpy.errstate', 'numpy.seterr', 'numpy.bincount',
 'numpy.core._multiarray_umath.bincount', 'numpy.core._multiarray_umath.datetime_as_string',
 'numpy.core._multiarray_umath.normalize_axis_index', 'numpy.core._multiarray_umath.shares_memory',
@@ -55,7 +56,7 @@ IncorrectInternalDocsLen = [
     "numpy.lib._datasource.DataSource._splitzipext",
     "numpy.core._internal._view_is_safe",
     "numpy.distutils.misc_util.Configuration.__init__",]
-AssertionError = [ 
+AssertionError = [
     "numpy.polynomial.polynomial.polyvalfromroots",
     "numpy.random.bit_generator.ISeedSequence.generate_state",
 ]

--- a/examples/pandas.toml
+++ b/examples/pandas.toml
@@ -1,4 +1,5 @@
-[pandas]
+[global]
+module = 'pandas'
 logo = 'logo_pandas.png'
 exec_failure = "fallback"
 submodules = []
@@ -90,7 +91,7 @@ exclude = [
     "pandas.core.common.pipe"
 ]
 [pandas.expected_errors]
-ValueError =[ "pandas.io.pickle.to_pickle", "pandas.core.generic.NDFrame.to_pickle",]           
+ValueError =[ "pandas.io.pickle.to_pickle", "pandas.core.generic.NDFrame.to_pickle",]
 IncorrectInternalDocsLen = [
     "pandas.core.indexes.period.PeriodIndex.asof_locs",
     "pandas.core.indexes.range.RangeIndex._extended_gcd", "pandas._testing._io.optional_args",

--- a/examples/papyri.toml
+++ b/examples/papyri.toml
@@ -1,4 +1,5 @@
-[papyri]
+[global]
+module = 'papyri'
 submodules = ['examples']
 examples_folder = '~/dev/papyri/docs/examples/'
 logo = "../papyri-logo.png"

--- a/examples/scipy.toml
+++ b/examples/scipy.toml
@@ -1,4 +1,5 @@
-[scipy]
+[global]
+module = 'scipy'
 logo = "../scipy_logo.png"
 exec = true
 submodules = [ "signal",]
@@ -47,7 +48,7 @@ IncorrectInternalDocsLen = [
     "scipy.interpolate._fitpack_py.spalde", "scipy.interpolate._fitpack_impl.spalde",
     "scipy.optimize._lsq.common.regularized_lsq_operator",
     "scipy.optimize._trustregion_constr.tr_interior_point.tr_interior_point",
-    "scipy.sparse._bsr.bsr_matrix.check_format",    
+    "scipy.sparse._bsr.bsr_matrix.check_format",
     "scipy.optimize._trustregion_constr.tr_interior_point.BarrierSubproblem.gradient_and_jacobian",
     ]
 VisitCitationReferenceNotImplementedError = [

--- a/examples/skimage.toml
+++ b/examples/skimage.toml
@@ -1,4 +1,5 @@
-[skimage]
+[global]
+module = 'skimage'
 logo = "../skimage-logo.png"
 exec_failure = "fallback"
 submodules = [ "morphology", "color", "data", "draw", "exposure", "io", "graph", "segmentation", "transform", "util", "viewer",]

--- a/papyri/gen.py
+++ b/papyri/gen.py
@@ -587,14 +587,18 @@ def load_configuration(
 ) -> Tuple[str, MutableMapping[str, Any], Dict[str, Any]]:
     """
     Given a path, load a configuration from a File.
+
+    Each configuration file should have two sections: ['global', 'meta'] where
+    the name of the module should be defined under the 'global' section.
     """
     conffile = Path(path).expanduser()
     if conffile.exists():
         conf: MutableMapping[str, Any] = toml.loads(conffile.read_text())
         ks = set(conf.keys()) - {"meta"}
         assert len(ks) == 1, conf.keys()
-        root = next(iter(conf.keys()))
-        return root, conf[root], conf.get("meta", {})
+        info = conf['global']
+        root = info.pop('module')
+        return root, info, conf.get("meta", {})
     else:
         sys.exit(f"{conffile!r} does not exists.")
 

--- a/papyri/gen.py
+++ b/papyri/gen.py
@@ -590,14 +590,15 @@ def load_configuration(
 
     Each configuration file should have two sections: ['global', 'meta'] where
     the name of the module should be defined under the 'global' section.
+    Additionally, a section for expected errors can be defined.
     """
     conffile = Path(path).expanduser()
     if conffile.exists():
         conf: MutableMapping[str, Any] = toml.loads(conffile.read_text())
         ks = set(conf.keys()) - {"meta"}
-        assert len(ks) == 1, conf.keys()
-        info = conf['global']
-        root = info.pop('module')
+        assert len(ks) >= 1, conf.keys()
+        info = conf["global"]
+        root = info.pop("module")
         return root, info, conf.get("meta", {})
     else:
         sys.exit(f"{conffile!r} does not exists.")


### PR DESCRIPTION
This PR:

- [x] Adds the `global` module to all of the toml files under the examples directory defining a `module` with its name
- [x] Fixes the `gen` file loading mechanism to support the changes

Fixes #104  