### PR TITLE
Print details about example failures

### DIFF
--- a/papyri/gen.py
+++ b/papyri/gen.py
@@ -968,7 +968,7 @@ class Gen:
 
         FORMAT = "%(message)s"
         logging.basicConfig(
-            level="INFO", format=FORMAT, datefmt="[%X]", handlers=[RichHandler()]
+            level="INFO", format=FORMAT, datefmt="[%X]", handlers=[RichHandler(rich_tracebacks=True)]
         )
 
         self.log = logging.getLogger("papyri")
@@ -1102,7 +1102,22 @@ class Gen:
                             ce_status = "execed"
                         except Exception:
                             if "Traceback" not in "\n".join(out):
-                                log.exception("error in execution: %s", qa)
+                                script = script.replace("\n", "\n>>> ")
+                                script = ">>> " + script
+
+                                meta_ = obj.__code__
+                                obj_fname = meta_.co_filename
+                                obj_lineno = meta_.co_firstlineno
+                                obj_name = meta_.co_name
+
+                                example_section_split = "\n".join(example_section).split(script)
+                                err_lineno = example_section_split[0].count("\n")
+                                log.exception(
+                                    "error in execution: "
+                                    f"{obj_fname}:{obj_lineno} in {obj_name}"
+                                    f"\n-> Example section line {err_lineno}:"
+                                    f"\n\n{script}\n",
+                                )
                             ce_status = "exception_in_exec"
                             if config.exec_failure != "fallback":
                                 raise


### PR DESCRIPTION
Print a bit more info such as the file path, lineno and lineno in the example section (I did not look into getting the lineno from the start of the docstrings nor the absolute lineno).

<img width="1677" alt="Screenshot 2022-10-31 at 17 37 24" src="https://user-images.githubusercontent.com/23188539/199061286-e82d026b-8933-47c3-b9b7-92325a8a1a8d.png">

Also, I decided to not print the whole example as it's quite large otherwise and I also did not find a nice colorset. Just for reference here is some code I wrote that would do that:

```python
script = script.replace("\n", "\n>>> ")
script = ">>> " + script
example_section_split = "\n".join(example_section).split(script)
example_section_format = f"[bold red]{script}[/bold red]".join(example_section_split)
example_section_format = f"[green]{example_section_format}[/green]"
log.exception(
    ...
    f"{example_section_format}",
    extra={"markup": True}
)
```

