### PR TITLE
Update IPython configuration file to be more precise about errors.

### DIFF
--- a/examples/IPython.toml
+++ b/examples/IPython.toml
@@ -4,34 +4,27 @@ logo = "../ipython-logo.png"
 exec_failure = "fallback"
 docs_path = "~/dev/IPython/docs/source"
 exec = true
-exclude = [
-    'IPython.lib.display.Audio',
-    'IPython.core.magics.execution.ExecutionMagics.run',
-    'IPython.core.magics.script.ScriptMagics.shebang',
-    'IPython.core.magics.basic.BasicMagics.alias_magic',
-    #'IPython.utils.text.strip_email_quotes',
-    # requires IPython instance
-    'IPython.core.display_functions.display',
-    #"ExecError-<class 'ValueError'>": [
-    "IPython.core.magics.basic.BasicMagics.colors",
-    "IPython.core.magics.config.ConfigMagics.config",
-    "IPython.core.magics.execution.ExecutionMagics.time",
-    "IPython.core.magics.namespace.NamespaceMagics.psearch",
-    "IPython.core.magics.namespace.NamespaceMagics.who_ls",
-    "IPython.core.magics.namespace.NamespaceMagics.who",
-    "IPython.core.magics.namespace.NamespaceMagics.whos",
-    "IPython.core.magics.namespace.NamespaceMagics.reset_selective",
-    "IPython.core.magics.pylab.PylabMagics.matplotlib",
-    "IPython.core.magics.basic.BasicMagics.notebook",
-    "IPython.core.magics.display.DisplayMagics.html",
-    "IPython.core.magics.execution.ExecutionMagics.debug",
-    "IPython.core.magics.namespace.NamespaceMagics.xdel",
-    "IPython.core.magics.execution.ExecutionMagics.capture",
-    "IPython.core.magics.history.HistoryMagics.history",
-    "IPython.core.magics.osm.OSMagics.writefile",
-    "IPython.core.magics.pylab.PylabMagics.pylab",
-    "IPython.terminal.embed.EmbeddedMagics.kill_embedded"
+execute_exclude_patterns = [
+   'IPython.lib.display.Audio',
+   'IPython.core.display_functions.display'
 ]
+exclude = []
+[global.expected_errors]
+IncorrectInternalDocsLen = [
+  "IPython.core.magics.basic.BasicMagics.alias_magic",
+  "IPython.core.magics.script.ScriptMagics.shebang",
+  "IPython.core.magics.basic.BasicMagics.notebook",
+  "IPython.core.magics.display.DisplayMagics.html",
+  "IPython.core.magics.execution.ExecutionMagics.debug",
+  "IPython.core.magics.execution.ExecutionMagics.capture",
+  "IPython.core.magics.history.HistoryMagics.history",
+  "IPython.core.magics.namespace.NamespaceMagics.xdel",
+  "IPython.core.magics.osm.OSMagics.writefile",
+  "IPython.core.magics.pylab.PylabMagics.matplotlib",
+  "IPython.core.magics.pylab.PylabMagics.pylab",
+  "IPython.terminal.embed.EmbeddedMagics.kill_embedded",
+]
+
 [meta]
 github_slug = 'IPython/IPython'
 tag = '8.2.0'

--- a/papyri/gen.py
+++ b/papyri/gen.py
@@ -412,6 +412,8 @@ class Config:
     narrative_exclude: Sequence[str] = ()
     exclude_jedi: Sequence[str] = ()
     implied_imports: Dict[str, str] = dataclasses.field(default_factory=dict)
+    # mapping from expected name of error instances, to which fully-qualified names are raising those errors.
+    # the build will fail if the given item does not raise this error.
     expected_errors: Dict[str, List[str]] = dataclasses.field(default_factory=dict)
     early_error: bool = True
     fail_unseen_error: bool = False


### PR DESCRIPTION
Instead of just excluding the items from documentation building, we tag which error are currently being emitted, so that when we fix those parsing errors,  we'll get a warning and can remove the objects from quarantine. 

From two of those objects that actually need an IPython instance, we simply mark them as not-executable. 