### PR TITLE
Partial update & update numpy configuration file.

### DIFF
--- a/examples/numpy.toml
+++ b/examples/numpy.toml
@@ -18,12 +18,31 @@ execute_exclude_patterns = ['numpy._','numpy.testing._priv', 'numpy.errstate', '
 'numpy.lib.npyio._read',
 ]
 
-submodules = ['distutils','typing','dual']
+submodules = [
+    'array_api',
+    'compat',
+    'core',
+    'ctypeslib',
+    'distutils',
+    'doc',
+    'dual',
+    'fft',
+    'lib',
+    'linalg',
+    'ma',
+    'matlib',
+    'matrixlib',
+    'polynomial',
+    'random',
+    'testing',
+    'tests',
+    'typing',
+    'version',
+]
 
 docs_path = '~/dev/numpy/doc/source'
 
 exec = true
-exclude = ['numpy._from_dlpack','numpy.lib.utils.get_include','numpy.core.shape_base._concatenate_shapes']
 narrative_exclude = ['doc/source/reference/arrays.ndarray.rst']
 exec_failure = 'fallback'
 source = 'https://github.com/numpy/numpy'

--- a/papyri/__init__.py
+++ b/papyri/__init__.py
@@ -420,6 +420,7 @@ def gen(
     fail_unseen_error: bool = typer.Option(
         False, help="Overwrite fail on unseen error option"
     ),
+    only: List[str] = typer.Option(None, "--only"),
 ):
     """
     Generate documentation for a given package.
@@ -458,6 +459,7 @@ def gen(
                 narrative=narrative,
                 fail_early=fail_early,
                 fail_unseen_error=fail_unseen_error,
+                limit_to=only,
             )
 
 

--- a/papyri/gen.py
+++ b/papyri/gen.py
@@ -1856,9 +1856,9 @@ class Gen:
         collected = {k: v for k, v in collected.items() if k not in excluded}
         if limit_to:
             collected = {k: v for k, v in collected.items() if k in limit_to}
-            print("DEV: regenerating docs only for")
+            self.log.info("DEV: regenerating docs only for")
             for k, v in collected.items():
-                print(f"    {k}:{v}")
+                self.log.info(f"    {k}:{v}")
         aliases: Dict[FullQual, Cannonical]
         aliases, not_found = collector.compute_aliases()
         rev_aliases: Dict[Cannonical, FullQual] = {v: k for k, v in aliases.items()}

--- a/papyri/gen.py
+++ b/papyri/gen.py
@@ -1824,9 +1824,9 @@ class Gen:
             module name to generate docbundle for.
         limit_to : list of string
             For partial documentation building and testing purposes
-            we may want to generate documentation only a single item.
+            we may want to generate documentation for only a single item.
             If this list is non-empty we will collect documentation
-            just for this item.
+            just for these items.
 
         See Also
         --------

--- a/papyri/gen.py
+++ b/papyri/gen.py
@@ -458,6 +458,7 @@ def gen_main(
     narrative,
     fail_early: bool,
     fail_unseen_error: bool,
+    limit_to=None,
 ) -> None:
     """
     Main entry point to generate docbundle files,
@@ -499,6 +500,8 @@ def gen_main(
     None
 
     """
+    if limit_to is None:
+        limit_to = set()
     target_module_name, conf, meta = load_configuration(target_file)
     conf["early_error"] = fail_early
     conf["fail_unseen_error"] = fail_unseen_error
@@ -530,7 +533,7 @@ def gen_main(
     if examples:
         g.collect_examples_out()
     if api:
-        g.collect_api_docs(target_module_name)
+        g.collect_api_docs(target_module_name, limit_to=limit_to)
     if narrative:
         g.collect_narrative_docs()
 
@@ -538,8 +541,11 @@ def gen_main(
     p.mkdir(exist_ok=True)
 
     g.log.info("Saving current Doc bundle to %s", p)
-    g.clean(p)
-    g.write(p)
+    if not limit_to:
+        g.clean(p)
+        g.write(p)
+    else:
+        g.partial_write(p)
     if dry_run:
         temp_dir.cleanup()
 
@@ -975,7 +981,15 @@ class Gen:
             handlers=[RichHandler(rich_tracebacks=True)],
         )
 
+        # TODO:
+        # At some point it would be better to have that be matplotlib
+        # specific and not hardcoded.
         class MF(logging.Filter):
+            """
+            This is a matplotlib filter to temporarily silence a bunch of warning
+            messages that are emitted if font are not found
+
+            """
             def filter(self, record):
                 if "Generic family" in record.msg:
                     return 0
@@ -983,6 +997,8 @@ class Gen:
 
         mlog = logging.getLogger("matplotlib.font_manager")
         mlog.addFilter(MF("serif"))
+
+        # end TODO
 
         self.log = logging.getLogger("papyri")
         self.config = config
@@ -1316,6 +1332,9 @@ class Gen:
         (where / "module").mkdir(exist_ok=True)
         for k, v in self.data.items():
             (where / "module" / (k + ".json")).write_bytes(v.to_json())
+
+    def partial_write(self, where):
+        self.write_api(where)
 
     def write(self, where: Path):
         """
@@ -1794,10 +1813,7 @@ class Gen:
         self._meta.update({"logo": logo, "module": root, "version": self.version})
         self._meta.update(meta)
 
-    def collect_api_docs(
-        self,
-        root: str,
-    ):
+    def collect_api_docs(self, root: str, limit_to: List[str]):
         """
         Crawl one module and stores resulting docbundle in self.store.
 
@@ -1805,6 +1821,11 @@ class Gen:
         ----------
         root : str
             module name to generate docbundle for.
+        limit_to : list of string
+            For partial documentation building and testing purposes
+            we may want to generate documentation only a single item.
+            If this list is non-empty we will collect documentation
+            just for this item.
 
         See Also
         --------
@@ -1832,6 +1853,11 @@ class Gen:
             )
 
         collected = {k: v for k, v in collected.items() if k not in excluded}
+        if limit_to:
+            collected = {k: v for k, v in collected.items() if k in limit_to}
+            print(f"DEV: regenerating docs only for")
+            for k, v in collected.items():
+                print(f"    {k}:{v}")
         aliases: Dict[FullQual, Cannonical]
         aliases, not_found = collector.compute_aliases()
         rev_aliases: Dict[Cannonical, FullQual] = {v: k for k, v in aliases.items()}

--- a/papyri/gen.py
+++ b/papyri/gen.py
@@ -990,6 +990,7 @@ class Gen:
             messages that are emitted if font are not found
 
             """
+
             def filter(self, record):
                 if "Generic family" in record.msg:
                     return 0
@@ -1855,7 +1856,7 @@ class Gen:
         collected = {k: v for k, v in collected.items() if k not in excluded}
         if limit_to:
             collected = {k: v for k, v in collected.items() if k in limit_to}
-            print(f"DEV: regenerating docs only for")
+            print("DEV: regenerating docs only for")
             for k, v in collected.items():
                 print(f"    {k}:{v}")
         aliases: Dict[FullQual, Cannonical]


### PR DESCRIPTION
    Add option to regenerate documentation only for some items.

    When debugging or iterating on the docs it should be interesting to
    be able to update the intermediate bundle with only some elements
    For example because you are updating the docs.

    This adds a flag --only , that can be passed multiple time at the CLI,
    and will ask the gen step to only collect documentation for those
    objects, and update the doc bundle instead of regenerating it.

    It is likely imperfect and  hence why it's only a cli flag.

    I'm not happy withe the name --only. Maybe --update ?