### PR TITLE
Fix types to match MyST spec

### DIFF
--- a/papyri/miniserde.py
+++ b/papyri/miniserde.py
@@ -195,6 +195,9 @@ def deserialize(type_, annotation, data):
                 else:
                     return deserialize(inner_annotation[0], inner_annotation[0], data)
             real_type = [t for t in inner_annotation if t.__name__ == data["type"]]
+            if len(real_type) == 0:
+                myst_type = f"M{data['type'][0].upper()}{data['type'][1:]}"
+                real_type = [t for t in inner_annotation if t.__name__ == myst_type]
             # assert len(real_type) == 1, real_type
             real_type = real_type[0]
             if data.get("data"):

--- a/papyri/myst_serialiser.py
+++ b/papyri/myst_serialiser.py
@@ -51,8 +51,8 @@ def serialize(instance, annotation):
         ann_ = ma[0]
         serialized_data = serialize(instance, ann_)
         if isinstance(serialized_data, dict):
-            return {"type": ann_.__name__, **serialized_data}
-        return {"type": ann_.__name__, "data": serialized_data}
+            return {**serialized_data, "type": ann_.type}
+        return {"data": serialized_data, "type": ann_.type}
     if (
         (type(annotation) is type)
         and type.__module__ not in ("builtins", "typing")

--- a/papyri/myst_serialiser.py
+++ b/papyri/myst_serialiser.py
@@ -50,9 +50,12 @@ def serialize(instance, annotation):
         # assert len(ma) == 1
         ann_ = ma[0]
         serialized_data = serialize(instance, ann_)
+        type_ = ann_.__name__
+        if hasattr(ann_, "type"):
+            type_ = ann_.type
         if isinstance(serialized_data, dict):
-            return {**serialized_data, "type": ann_.type}
-        return {"data": serialized_data, "type": ann_.type}
+            return {**serialized_data, "type": type_}
+        return {"data": serialized_data, "type": type_}
     if (
         (type(annotation) is type)
         and type.__module__ not in ("builtins", "typing")

--- a/papyri/tests/corpus/no-space-parenthesis.expected.txt
+++ b/papyri/tests/corpus/no-space-parenthesis.expected.txt
@@ -1,1 +1,1 @@
-[{"type": "Section", "children": [{"type": "MParagraph", "children": [{"type": "MText", "value": "there should not be spaces ("}, {"type": "MInlineCode", "value": "between"}, {"type": "MText", "value": ") the parenthesis."}]}], "title": null, "level": 0, "target": null}]
+[{"type": "Section", "children": [{"type": "paragraph", "children": [{"type": "text", "value": "there should not be spaces ("}, {"type": "inlineCode", "value": "between"}, {"type": "text", "value": ") the parenthesis."}]}], "title": null, "level": 0, "target": null}]

--- a/papyri/tests/corpus/test.expected.txt
+++ b/papyri/tests/corpus/test.expected.txt
@@ -1,1 +1,1 @@
-[{"type": "Section", "children": [{"type": "MParagraph", "children": [{"type": "MText", "value": "This is just text."}]}], "title": null, "level": 0, "target": null}]
+[{"type": "Section", "children": [{"type": "paragraph", "children": [{"type": "text", "value": "This is just text."}]}], "title": null, "level": 0, "target": null}]


### PR DESCRIPTION
Another step to bring the json more closer to the myst spec.

Example:

```json
        {
          "children": [
            {
              "type": "text",
              "value": "For configuring the preference for and location of libraries like BLAS and LAPACK, and for setting include paths and similar build options, please see "
            },
            {
              "type": "inlineCode",
              "value": "site.cfg.example"
            },
            {
              "type": "text",
              "value": " in the root of the NumPy repository or sdist."
            }
          ],
          "type": "paragraph"
        }
```