### PR TITLE
Add MAdmonition from MyST

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -57,7 +57,7 @@ jobs:
         sleep 1 # time for coverage to write its stuff
     - name: Self gen
       run: |
-        coverage run -a -m papyri gen examples/papyri.toml  --exec --no-narrative
+        coverage run -a -m papyri gen examples/papyri.toml  --exec
         sleep 1 # time for coverage to write its stuff
     - name: Ingest
       run: |

--- a/papyri/myst_ast.py
+++ b/papyri/myst_ast.py
@@ -145,14 +145,14 @@ class MMystDirective(Node):
 @register(4055)
 class MAdmonitionTitle(Node):
     type = "admonitionTitle"
-    children: List["PhrasingContent"] = []
+    children: List[Union["PhrasingContent", None]] = []
 
 
 @register(4056)
 class MAdmonition(Node):
     type = "admonition"
-    kind: str
-    children: List[Union["FlowContent", "AdmonitionTitle"]] = []
+    children: List[Union["FlowContent", "MAdmonitionTitle", take2.Unimplemented]] = []
+    kind: str = "note"
 
 
 StaticPhrasingContent = Union[

--- a/papyri/myst_ast.py
+++ b/papyri/myst_ast.py
@@ -206,6 +206,4 @@ FlowContent = Union[
     # MFootnoteDefinition,
 ]
 
-ListContent = Union[
-    MListItem,
-]
+ListContent = Union[MListItem,]

--- a/papyri/myst_ast.py
+++ b/papyri/myst_ast.py
@@ -156,6 +156,7 @@ class MAdmonition(Node):
             "FlowContent",
             "MAdmonitionTitle",
             take2.Unimplemented,
+            "take2.BlockQuote",
             "take2.DefList",
         ]
     ] = []

--- a/papyri/myst_ast.py
+++ b/papyri/myst_ast.py
@@ -151,7 +151,14 @@ class MAdmonitionTitle(Node):
 @register(4056)
 class MAdmonition(Node):
     type = "admonition"
-    children: List[Union["FlowContent", "MAdmonitionTitle", take2.Unimplemented]] = []
+    children: List[
+        Union[
+            "FlowContent",
+            "MAdmonitionTitle",
+            take2.Unimplemented,
+            "take2.DefList",
+        ]
+    ] = []
     kind: str = "note"
 
 
@@ -199,4 +206,6 @@ FlowContent = Union[
     # MFootnoteDefinition,
 ]
 
-ListContent = Union[MListItem,]
+ListContent = Union[
+    MListItem,
+]

--- a/papyri/myst_ast.py
+++ b/papyri/myst_ast.py
@@ -142,6 +142,19 @@ class MMystDirective(Node):
     children: List[Union["FlowContent", "PhrasingContent", None]] = []
 
 
+@register(4055)
+class MAdmonitionTitle(Node):
+    type = "admonitionTitle"
+    children: List["PhrasingContent"] = []
+
+
+@register(4056)
+class MAdmonition(Node):
+    type = "admonition"
+    kind: str
+    children: List[Union["FlowContent", "AdmonitionTitle"]] = []
+
+
 StaticPhrasingContent = Union[
     MText,
     MInlineCode,
@@ -179,7 +192,7 @@ FlowContent = Union[
     # MComment,
     # MTarget,
     MMystDirective,
-    # MAdmonition,
+    MAdmonition,
     # MContainer,
     # MMath,
     # MTable,

--- a/papyri/take2.py
+++ b/papyri/take2.py
@@ -216,6 +216,7 @@ from .myst_ast import (
     MCode,
     MStrong,
     MLink,
+    MAdmonition,
 )
 
 
@@ -324,6 +325,7 @@ class ListItem(Node):
             BlockMath,
             Unimplemented,
             Admonition,
+            MAdmonition,
             Comment,
             MParagraph,
             MCode,
@@ -386,6 +388,7 @@ class Section(Node):
             MList,
             BlockQuote,
             Admonition,
+            MAdmonition,
             FieldList,
             Target,
             SubstitutionRef,
@@ -447,6 +450,7 @@ class Param(Node):
             BlockMath,
             BlockVerbatim,
             Admonition,
+            MAdmonition,
             BulletList,
             BlockQuote,
             MList,
@@ -579,6 +583,7 @@ class BlockQuote(Node):
             BlockQuote,
             FieldList,
             Admonition,
+            MAdmonition,
             Unimplemented,
             Comment,
             BlockMath,
@@ -800,6 +805,7 @@ class DefListItem(Node):
             MMystDirective,
             Unimplemented,
             Admonition,
+            MAdmonition,
             BlockMath,
             BlockVerbatim,
             Optional[TocTree],  # remove this, that should not be the case ?

--- a/papyri/tree.py
+++ b/papyri/tree.py
@@ -11,7 +11,6 @@ from functools import lru_cache
 from typing import Any, Dict, FrozenSet, List, Set, Tuple, Callable
 
 from .take2 import (
-    Admonition,
     BlockDirective,
     BlockMath,
     BlockVerbatim,
@@ -30,7 +29,7 @@ from .take2 import (
     Verbatim,
 )
 from .common_ast import Node
-from .myst_ast import MMystDirective, MLink, MText
+from .myst_ast import MMystDirective, MLink, MText, MAdmonition
 from .utils import full_qual
 from textwrap import indent
 from .ts import parse
@@ -617,7 +616,7 @@ class DirectiveVisiter(TreeReplacer):
             assert isinstance(inner[0], Section)
 
             return [
-                Admonition(
+                MAdmonition(
                     name,
                     argument,
                     inner[0].children,
@@ -625,7 +624,7 @@ class DirectiveVisiter(TreeReplacer):
             ]
         else:
             return [
-                Admonition(
+                MAdmonition(
                     name,
                     argument,
                     [],

--- a/papyri/tree.py
+++ b/papyri/tree.py
@@ -29,7 +29,7 @@ from .take2 import (
     Verbatim,
 )
 from .common_ast import Node
-from .myst_ast import MMystDirective, MLink, MText, MAdmonition
+from .myst_ast import MMystDirective, MLink, MText, MAdmonition, MAdmonitionTitle
 from .utils import full_qual
 from textwrap import indent
 from .ts import parse
@@ -617,17 +617,15 @@ class DirectiveVisiter(TreeReplacer):
 
             return [
                 MAdmonition(
-                    name,
-                    argument,
-                    inner[0].children,
+                    [
+                        MAdmonitionTitle([MText(f"{name} {argument}")])
+                    ] + inner[0].children,
                 )
             ]
         else:
             return [
                 MAdmonition(
-                    name,
-                    argument,
-                    [],
+                    [MAdmonitionTitle([MText(f"{name} {argument}")])],
                 )
             ]
 

--- a/papyri/tree.py
+++ b/papyri/tree.py
@@ -617,9 +617,8 @@ class DirectiveVisiter(TreeReplacer):
 
             return [
                 MAdmonition(
-                    [
-                        MAdmonitionTitle([MText(f"{name} {argument}")])
-                    ] + inner[0].children,
+                    [MAdmonitionTitle([MText(f"{name} {argument}")])]
+                    + inner[0].children,
                 )
             ]
         else:


### PR DESCRIPTION
- [x] TODO: Would need to incorporate `MAdmonitionTitle` during the creation of Admonition.

Example from [myst spec](https://myst-tools.org/docs/spec/admonitions#example):

```yaml
type: root
children:
  - type: mystDirective
    name: admonition
    args: This is a title
    value: An example of an admonition with a _title_.
    children:
      - type: admonition
        children:
          - type: admonitionTitle
            children:
              - type: text
                value: This is a title
          - type: paragraph
            children:
              - type: text
                value: 'An example of an admonition with a '
```