### PR TITLE
Fix permissions issue with deploy preview

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -4,6 +4,10 @@ on:
   pull_request_target:
     branches: [ main ]
 
+permissions:
+  contents: read
+  statuses: write
+
 env:
   VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
   VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}


### PR DESCRIPTION
By default the `github.token` doesn't have write access to update commit status with deployment url and this cannot be set at repository level from settings, as it's set on the organization level to give read-only permissions by default. This PR overrides it at the workflow level. See https://github.com/jupyter/papyri/pull/227#issuecomment-1466064487 and https://github.com/jupyter/papyri/pull/227#issuecomment-1466827409