### PR TITLE
Vercel deploy to prod (`main` branch)

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -134,3 +134,49 @@ jobs:
       with:
         fail_ci_if_error: true
         token: ${{ secrets.CODECOV_TOKEN }}
+
+  vercel-deploy-prod:
+    runs-on: ubuntu-latest
+    needs: [build]
+    if: github.ref == 'refs/heads/main'
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+        cache: 'pip'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install pytest pytest-cov flit matplotlib 'velin>=0.0.5' pytest-trio tree_sitter coverage 'jinja2<3.1'
+        flit install --symlink
+        git clone https://github.com/stsewd/tree-sitter-rst
+        papyri build-parser
+    - uses: actions/download-artifact@v3
+      with:
+        name: doc-bundles
+        path: ~/.papyri/data/
+
+    - name: Ingest and Render
+      run: |
+        papyri install ~/.papyri/data/*.zip
+        papyri relink
+        papyri render
+
+    - name: Install Vercel CLI
+      run: npm install --global vercel@latest
+
+    - name: Deploy Project Artifacts to Vercel
+      id: vercel
+      working-directory: "/home/runner/.papyri/html"
+      run: |
+        vercel --version
+        vercel pull --yes --environment=production --token=$VERCEL_TOKEN
+        vercel build --prod --token=$VERCEL_TOKEN
+        vercel deploy --prebuilt --prod --archive=tgz --token=$VERCEL_TOKEN --meta commit=${{ github.sha }}
+      env:
+        VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+        VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+        VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}


### PR DESCRIPTION
This will deploy the latest `main` branch (using the built artifacts) at https://papyri.vercel.app/, to always have at least one stable deployment and also useful for comparison with branch/PR deployments.

Current deployment: https://papyri.vercel.app/