### PR TITLE
Replace Code2 with MyST Code

### DIFF
--- a/papyri/examples.tpl.j2
+++ b/papyri/examples.tpl.j2
@@ -11,17 +11,8 @@
        {%- set type = data.__class__.__name__ -%}
        {% if type == 'Fig' %}
            <div><img src="/p/{{data.value.module}}/{{data.value.version}}/img/{{data.value.path}}"/></div>
-       {% elif type == 'Code2' %}
-           {% if data.ce_status == 'syntax_error' -%}
-               <span class='warning'>This example raised an error at execution time but compiled correctly</span>
-           {%-elif data.ce_status == 'exception_in_exec' -%}
-               <span class='warning'>This example is valid syntax, but raise an exception at execution</span>
-           {%-elif data.ce_status == 'compiled' -%}
-               <span class='note'>This example is valid syntax, but we were not able to check execution</span>
-           {%-endif-%}
-       <pre class='highlight {{data.ce_status}}'>{{example(data.entries) -}}
-
-        {{- data.out}}</pre>
+       {% elif type[0] == 'M' %}
+            {{ render_myst(obj) }}
        {% else %}
            {{render_II(data)}}
        {% endif %}

--- a/papyri/html.tpl.j2
+++ b/papyri/html.tpl.j2
@@ -14,7 +14,7 @@
 {%block api %}
 
 
-{% from 'macros.tpl.j2' import render_inner, block_paragraph, render_paragraph, lines, block, myst_directive, example, render_II with context %}
+{% from 'macros.tpl.j2' import render_inner, block_paragraph, render_paragraph, lines, block, myst_directive, example, render_myst, render_II with context %}
 {% from 'graph.tpl.j2' import d3script with context%}
 
 
@@ -95,6 +95,8 @@
                 {{render_paragraph(data)}}
             {% elif type == 'Fig' %}
                 <div><img src="/p/{{data.value.module}}/{{data.value.version}}/img/{{data.value.path}}"/></div>
+            {% elif type[0] == 'M' %}
+                {{ render_myst(data) }}
             {% elif type == 'Code2' %}
                 {% if data.ce_status == 'syntax_error' -%}
                     <span class='warning'>This example does not not appear to be valid Python Syntax</span>

--- a/papyri/macros.tpl.j2
+++ b/papyri/macros.tpl.j2
@@ -111,6 +111,8 @@
        {%- if type in ('Directive', 'Math', 'Verbatim') -%}
            {# {{unreachable(obj)}} #}
            {{obj.value}}  {# TODO : likely smth wrong with field list #}
+       {% elif type[0] == 'M' %}
+            {{ render_myst(obj) }}
        {%- elif type == 'Link' -%}
 
            {# Links have : value, reference, kind exists#}
@@ -159,7 +161,7 @@
                <li>{{render_II(item)}}</li>
                {% endfor %}
             </ol>
-        {% else %}
+            {% else %}
             <ul>
                {%- for item in obj.children %}
                <li>{{render_II(item)}}</li>
@@ -186,7 +188,7 @@
                {% endfor %}
            </dl>
 
-        {% elif type == 'FieldListItem' %}
+       {% elif type == 'FieldListItem' %}
            <ol>
                {%- for item in obj.children %}
                <li>{{render_II(item)}}</li>
@@ -198,7 +200,7 @@
        {% elif type == 'Transition' %}
          <hr/>
 
-     {% elif type == 'TocTree' %}
+       {% elif type == 'TocTree' %}
         {%if obj.children%}
             <details class='toctree' open>
             <summary><a class="toctree" href="{{url(obj.ref)}}">{{obj.title}}</a></summary>
@@ -216,9 +218,7 @@
             <blockquote>
                {%- for child in obj.children %}{{render_II(child)}}{% endfor -%}
             </blockquote>
-        {% elif type[0] == 'M' %}
-            {{ render_myst(obj) }}
-        {% elif type in ['Options','Unimplemented','Comment','SubstitutionRef'] %}
+       {% elif type in ['Options','Unimplemented','Comment','SubstitutionRef'] %}
            <pre class='not-implemented'>
             {{obj}}
            </pre>

--- a/papyri/take2.py
+++ b/papyri/take2.py
@@ -264,7 +264,6 @@ class Section(Node):
             # Code,
             MCode,
             MText,
-            Code2,
             Unimplemented,
             MComment,
             Target,
@@ -359,45 +358,6 @@ class Param(Node):
         return (
             f"<{self.__class__.__name__}: {self.param=}, {self.type_=}, {self.desc=}>"
         )
-
-
-@register(4017)
-class Token(Node):
-    """
-    A single token in a code block.
-
-    Paramters
-    ---------
-    type : str, optional
-        this currently is a classname use by pygments for highlighting.
-    link : str | Link(value, reference, kind, exists)
-        this is either a string (the value to display), or a link that point to a given page.
-
-    """
-
-    link: Union[Link, str]
-    type: Optional[str]
-
-    @property
-    def children(self):
-        return [self.link, self.type]
-
-    def __repr__(self):
-        return f"<{self.__class__.__name__}: {self.link=} {self.type=} >"
-
-
-@register(4020)
-class Code2(Node):
-    entries: List[Token]
-    out: str
-    ce_status: str
-
-    @property
-    def children(self):
-        return [*self.entries, self.out, self.ce_status]
-
-    def __repr__(self):
-        return f"<{self.__class__.__name__}: {self.entries=} {self.out=} {self.ce_status=}>"
 
 
 class GenToken(Node):

--- a/papyri/tree.py
+++ b/papyri/tree.py
@@ -11,12 +11,10 @@ from functools import lru_cache
 from typing import Any, Dict, FrozenSet, List, Set, Tuple, Callable
 
 from .take2 import (
-    Code2,
     Directive,
     Link,
     RefInfo,
     SubstitutionDef,
-    Token,
 )
 from .common_ast import Node
 from .myst_ast import (
@@ -339,7 +337,6 @@ class TreeReplacer:
             elif name in [
                 "BlockMath",
                 "Code",
-                "Code2",
                 "Comment",
                 "MComment",
                 "Directive",
@@ -533,57 +530,9 @@ class DirectiveVisiter(TreeReplacer):
         self._tocs: Any = []
 
     def replace_Code(self, code):
-        """
-        Here we'll crawl example data and convert code entries so that each token contain a link to the object they
-        refered to.
-        """
-        # TODO: here we'll have a problem as we will love the content of entry[1]. This should really be resolved at gen
-        # time.
-        # print("CODE 1 in", self.qa)
-        new_entries = []
-        for gt in code.entries:
-            text, infer, type_ = gt.value, gt.qa, gt.pygmentclass
-            assert isinstance(text, str)
-            # TODO
-            if infer and infer.strip():
-                assert isinstance(infer, str)
-                r = self._resolve(frozenset(), infer)
-                if r.kind == "module":
-                    self._targets.add(r)
-                    new_entries.append(
-                        Token(
-                            Link(
-                                text,
-                                r,
-                                "module",
-                                True,
-                            ),
-                            type_,
-                        )
-                    )
-                    continue
-                elif r.module is None:
-                    mod = infer.split(".", maxsplit=1)[0]
-                    new_entries.append(
-                        Token(
-                            Link(
-                                text,
-                                RefInfo(mod, "*", "module", infer),
-                                "module",
-                                True,
-                            ),
-                            type_,
-                        )
-                    )
-                else:
-                    assert False
-                continue
-
-            new_entries.append(
-                Token(text, type_),
-            )
-
-        return [Code2(new_entries, code.out, code.ce_status)]
+        """Here we'll return MySt Code."""
+        code_ = ''.join([entry.value for entry in code.entries])
+        return [MCode(code_)]
 
     def _block_verbatim_helper(self, name: str, argument: str, options: dict, content):
         data = f".. {name}:: {argument}\n"

--- a/papyri/tree.py
+++ b/papyri/tree.py
@@ -531,7 +531,7 @@ class DirectiveVisiter(TreeReplacer):
 
     def replace_Code(self, code):
         """Here we'll return MySt Code."""
-        code_ = ''.join([entry.value for entry in code.entries])
+        code_ = "".join([entry.value for entry in code.entries])
         return [MCode(code_)]
 
     def _block_verbatim_helper(self, name: str, argument: str, options: dict, content):


### PR DESCRIPTION
I'll remove `Code` in another iteration as that requires more work. This removes using pygments for syntax highlighting, I am hoping we'll use myst for styling / code highlighting.

The current `myst.renderMdast` function we're using is very basic and doesn't comes with much styling. See this https://github.com/executablebooks/mystjs/issues/369#issuecomment-1545785666