### PR TITLE
Replace Target with MyST `Target`

### DIFF
--- a/papyri/miniserde.py
+++ b/papyri/miniserde.py
@@ -201,6 +201,8 @@ def deserialize(type_, annotation, data):
                 myst_type = f"M{data['type'][0].upper()}{data['type'][1:]}"
                 if data["type"] == "mystComment":
                     myst_type = "MComment"
+                elif data["type"] == "mystTarget":
+                    myst_type = "MTarget"
                 real_type = [t for t in inner_annotation if t.__name__ == myst_type]
             # assert len(real_type) == 1, real_type
             try:

--- a/papyri/myst_ast.py
+++ b/papyri/myst_ast.py
@@ -185,6 +185,14 @@ class MBlockquote(Node):
     # data: Any
 
 
+@register(4061)
+class MTarget(Node):
+    type = "mystTarget"
+    label: str
+    # position: Any
+    # data: Any
+
+
 StaticPhrasingContent = Union[
     MText,
     MInlineCode,
@@ -219,7 +227,7 @@ FlowContent = Union[
     MList,
     # MHTML,
     # MComment,
-    # MTarget,
+    MTarget,
     MMystDirective,
     MAdmonition,
     # MContainer,

--- a/papyri/take2.py
+++ b/papyri/take2.py
@@ -158,11 +158,6 @@ class SubstitutionRef(Leaf):
     pass
 
 
-@register(4042)
-class Target(Leaf):
-    pass
-
-
 @register(4018)
 class Unimplemented(Node):
     placeholder: str
@@ -183,6 +178,7 @@ from .myst_ast import (
     MMath,
     MComment,
     MBlockquote,
+    MTarget,
 )
 
 
@@ -267,7 +263,7 @@ class Section(Node):
             Code2,
             Unimplemented,
             MComment,
-            Target,
+            MTarget,
             Fig,
             Options,
             MParagraph,
@@ -280,7 +276,7 @@ class Section(Node):
             MBlockquote,
             MAdmonition,
             FieldList,
-            Target,
+            MTarget,
             SubstitutionRef,
             SubstitutionDef,
         ]


### PR DESCRIPTION
 A minor one, just replacing the Target node with [MyST `MTarget`](https://myst-tools.org/docs/spec/references#target-node). This is a step towards replacing Links and References.
