### PR TITLE
Create dev requirements and upgrade jinja2

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install flit 'flake8<6' black mypy pipdeptree
+        pip install -r requirements-dev.txt
         flit install --symlink
     - name: dependency tree
       run: |

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -33,7 +33,8 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install pytest pytest-cov flit scipy numpy matplotlib 'velin>=0.0.5' pytest-trio tree_sitter coverage pipdeptree 'jinja2<3.1'
+        pip install -r requirements-dev.txt
+        pip install scipy numpy
         flit install --symlink
         git clone https://github.com/stsewd/tree-sitter-rst
         papyri build-parser

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -45,7 +45,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install flit matplotlib 'velin>=0.0.5' tree_sitter coverage pipdeptree 'jinja2<3.1'
+        pip install -r requirements-dev.txt
         flit install --symlink
         git clone https://github.com/stsewd/tree-sitter-rst
         papyri build-parser
@@ -95,7 +95,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install pytest pytest-cov flit matplotlib 'velin>=0.0.5' pytest-trio tree_sitter coverage 'jinja2<3.1'
+        pip install -r requirements-dev.txt
         flit install --symlink
         git clone https://github.com/stsewd/tree-sitter-rst
         papyri build-parser
@@ -150,7 +150,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install pytest pytest-cov flit matplotlib 'velin>=0.0.5' pytest-trio tree_sitter coverage 'jinja2<3.1'
+        pip install -r requirements-dev.txt
         flit install --symlink
         git clone https://github.com/stsewd/tree-sitter-rst
         papyri build-parser

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,13 @@
+pytest
+pytest-cov
+flit
+matplotlib
+velin>=0.0.5
+pytest-trio
+tree_sitter
+coverage
+jinja2==3.1.2
+pipdeptree
+black
+mypy
+flake8<6


### PR DESCRIPTION
CI Requirements are installed explicitly in every workflow, this creates a single file for the same and also (upgrades jinja2, will have to check the preview to see if anything is broken). Fixes #161 