### PR TITLE
Fix numpy generation `np.dual`, since release 1.25.0

### DIFF
--- a/examples/numpy.toml
+++ b/examples/numpy.toml
@@ -25,7 +25,6 @@ submodules = [
     'ctypeslib',
     'distutils',
     'doc',
-    'dual',
     'fft',
     'lib',
     'linalg',


### PR DESCRIPTION
Fixing the error:

```
ModuleNotFoundError: No module named 'numpy.dual'
```
Ref: https://github.com/jupyter/papyri/actions/runs/5322163212/jobs/9638224021

`numpy.dual` was deprecated in `1.24.0`

## numpy: `1.24.0`

```python
>>> import numpy as np
>>> np.dual
<module 'numpy.dual' from '/Users/aktech/miniconda3/envs/papyri/lib/python3.9/site-packages/numpy/dual.py'>
>>> np.__version__
'1.24.0'
```

## numpy: `1.25.0`

```
>>> import numpy as np
>>> np.dual
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/aktech/miniconda3/envs/papyri/lib/python3.9/site-packages/numpy/__init__.py", line 322, in __getattr__
    raise AttributeError("module {!r} has no attribute "
AttributeError: module 'numpy' has no attribute 'dual'
>>> np.__version__
'1.25.0'
```