### PR TITLE
Don't rely on global logging configuration

### DIFF
--- a/papyri/gen.py
+++ b/papyri/gen.py
@@ -1000,14 +1000,6 @@ class Gen:
             TimeElapsedColumn(),
         )
 
-        FORMAT = "%(message)s"
-        logging.basicConfig(
-            level="INFO",
-            format=FORMAT,
-            datefmt="[%X]",
-            handlers=[RichHandler(rich_tracebacks=True)],
-        )
-
         # TODO:
         # At some point it would be better to have that be matplotlib
         # specific and not hardcoded.
@@ -1037,7 +1029,15 @@ class Gen:
 
         # end TODO
 
+        FORMAT = "%(message)s"
         self.log = logging.getLogger("papyri")
+        self.log.setLevel("INFO")
+        formatter = logging.Formatter(FORMAT, datefmt="[%X]")
+        rich_handler = RichHandler(rich_tracebacks=True)
+        rich_handler.setLevel(logging.INFO)
+        rich_handler.setFormatter(formatter)
+        self.log.addHandler(rich_handler)
+
         self.config = config
         self.log.debug("Configuration: %s", self.config)
 


### PR DESCRIPTION
papyri imports modules, and these imports may change the global logging configuration. For example, importing numpy.distutils changes the logging level from INFO to WARNING. This was causing many messages to not be printed to the screen when generating documentation for numpy.

This fixes the issue I previously reported where papyri doesn't print where the files are written to. It actually does, it was just being hidden because of this. 