### PR TITLE
Fix handling of Control-C

### DIFF
--- a/papyri/gen.py
+++ b/papyri/gen.py
@@ -108,7 +108,7 @@ class ErrorCollector:
         pass
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        if exc_type is (BaseException, KeyboardInterrupt):
+        if exc_type in (BaseException, KeyboardInterrupt):
             return
         if exc_type:
             self.errored = True


### PR DESCRIPTION
A typo was preventing it from working if the exception handler caught it.