### PR TITLE
Use tomllib/tomli instead of toml

### DIFF
--- a/papyri/__init__.py
+++ b/papyri/__init__.py
@@ -173,7 +173,7 @@ import zipfile
 from pathlib import Path
 from typing import List, Optional
 
-import toml
+import tomli_w
 import typer
 
 from . import examples
@@ -488,7 +488,7 @@ def bootstrap(file: str):
     name = input(f"package name [{p.stem}]:")
     if not name:
         name = p.stem
-    p.write_text(toml.dumps(dict(name={"module": [name]})))
+    p.write_text(tomli_w.dumps(dict(name={"module": [name]})))
 
 
 @app.command()

--- a/papyri/gen.py
+++ b/papyri/gen.py
@@ -32,7 +32,11 @@ from types import FunctionType, ModuleType
 from typing import Any, Dict, FrozenSet, List, MutableMapping, Optional, Sequence, Tuple
 
 import jedi
-import toml
+try:
+    import tomllib
+except ModuleNotFoundError:
+    import tomli as tomllib
+import tomli_w
 from IPython.core.oinspect import find_file
 from IPython.utils.path import compress_user
 from pygments import lex
@@ -443,7 +447,7 @@ def load_configuration(
     """
     conffile = Path(path).expanduser()
     if conffile.exists():
-        conf: MutableMapping[str, Any] = toml.loads(conffile.read_text())
+        conf: MutableMapping[str, Any] = tomllib.loads(conffile.read_text())
         ks = set(conf.keys()) - {"meta"}
         assert len(ks) >= 1, conf.keys()
         info = conf["global"]
@@ -2086,11 +2090,11 @@ class Gen:
                 self.put_raw(name, data)
         if error_collector._errors:
             self.log.info(
-                "ERRORS:" + toml.dumps(error_collector._errors).replace(",", ",    \n")
+                "ERRORS:" + tomli_w.dumps(error_collector._errors).replace(",", ",    \n")
             )
         if error_collector._expected_unseen:
             self.log.info(
-                "UNSEEN ERRORS:" + toml.dumps(error_collector._expected_unseen)
+                "UNSEEN ERRORS:" + tomli_w.dumps(error_collector._expected_unseen)
             )
         if failure_collection:
             self.log.info(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,8 @@ dynamic = ["version","description"]
 requires-python=">=3.8"
 dependencies = [
     "typer",
-    "toml",
+    "tomli",
+    "tomli_w",
     "urwid",
     "httpx",
     "jinja2<3.1",
@@ -25,16 +26,16 @@ dependencies = [
     "rich",
     "jedi",
     "typer",
-    "velin", 
+    "velin",
     "quart-trio",
     "quart<0.14",
     "toml",
     "flatlatex",
     # "tree_sitter", # tree sitter does not currently provide builds for all platform. tree-sitter-builds is an
     # alternative build that provide more wheels.
-    "tree-sitter-builds", 
+    "tree-sitter-builds",
     "tree_sitter_languages>=1.5",
-    # 
+    #
     "matplotlib",
     "cbor2",
     "minify_html",


### PR DESCRIPTION
toml has a strange bug where its dumps() turns strings into arrays, leading to things like

```
NumpydocParseError = [ [ "n",
"u",
"m",
"p",
"y",
".",
"p",
"o",
"l",
"y",
"n",
"o",
"m",
"i",
"a",
"l",
".",
"_",
"p",
"o",
"l",
"y",
"b",
"a",
"s",
"e",
":",
"A",
"B",
"C",
"P",
"o",
"l",
"y",
"B",
"a",
"s",
"e",
],
]
```

in the log output, instead of the expected

```
NumpydocParseError = [
    "numpy.polynomial._polybase:ABCPolyBase",

]
```

In general, tomllib is part of the standard library starting with Python 3.11, and the tomli package is a compatible version for lower Python versions. tomli_w is the version of the package with writing capabilities, and doesn't seem to have this issue.

However, I'm not super familiar with toml parsing so if there are other good reasons to stick with `toml` for writing, or if there are better alternatives, we can do that. `tomlkit` is another option as it supports round-tripping https://github.com/sdispater/tomlkit. 