### PR TITLE
Make tomli a dependency only in Python < 3.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dynamic = ["version","description"]
 requires-python=">=3.8"
 dependencies = [
     "typer",
-    "tomli",
+    "tomli;python_version>='3.11'",
     "tomli_w",
     "urwid",
     "httpx",
@@ -29,7 +29,6 @@ dependencies = [
     "velin",
     "quart-trio",
     "quart<0.14",
-    "toml",
     "flatlatex",
     # "tree_sitter", # tree sitter does not currently provide builds for all platform. tree-sitter-builds is an
     # alternative build that provide more wheels.


### PR DESCRIPTION
Also remove toml as a dependency (it wasn't removed in #269 because apparently it was in there twice).

Fixes #271