### PR TITLE
Use a proper warning when a name is not found in a module

### DIFF
--- a/papyri/gen.py
+++ b/papyri/gen.py
@@ -606,6 +606,7 @@ class DFSCollector:
         self._open_list = [(root, [root.__name__])]
         for o in others:
             self._open_list.append((o, o.__name__.split(".")))
+        self.log = logging.getLogger("papyri")
 
     def scan(self) -> None:
         """
@@ -697,7 +698,7 @@ class DFSCollector:
         for k in dir(mod):
             # TODO: scipy 1.8 workaround, remove.
             if not hasattr(mod, k):
-                print_(f"scipy 1.8 workaround : ({mod.__name__!r},{k!r}),")
+                self.log.warning(f"Name not found in module: {mod.__name__}.{k}")
                 continue
             self._open_list.append((getattr(mod, k), stack + [k]))
 


### PR DESCRIPTION
Closes #278

Let me know if this fix is OK. I had to add the log object to the DFSCollector class. 

I haven't tried to update the scipy config as suggested in the issue. If we do that we need to make sure the docs all still get generated correctly. SciPy does a lot of weird dynamic stuff with its modules using module-level `__dir__` and `__getattr__`. 