### PR TITLE
Change object inspection logic

### DIFF
--- a/papyri/signature.py
+++ b/papyri/signature.py
@@ -87,18 +87,22 @@ class Signature:
         self._sig = inspect.signature(target_item)
 
     def to_node(self) -> SignatureNode:
-        if inspect.isbuiltin(self.target_item):
-            kind = "builtins"
-        elif inspect.isfunction(self.target_item):
+        kind = ""
+        if inspect.isfunction(self.target_item):
             kind = "function"
-        elif self.is_generator:
-            kind = "generator"
-        elif self.is_async_generator:
-            kind = "async_generator"
-        elif inspect.iscoroutinefunction(self.target_item):
-            kind = "coroutine_function"
-        else:
+        if inspect.isbuiltin(self.target_item):
+            kind = "built-in function"
+        if inspect.isgeneratorfunction(self.target_item):
+            kind = "generator function"
+        if inspect.isasyncgenfunction(self.target_item):
+            kind = "async_generator function"
+        if inspect.iscoroutinefunction(self.target_item):
+            kind = "coroutine function"
+        if kind == "":
             assert False, f"Unknown kind for {self.target_item}"
+
+        # Why do we want to make sure this is not a coroutine?
+        # What is special about a coroutine in this context?
         assert not inspect.iscoroutine(self.target_item)
 
         parameters = []

--- a/papyri/tests/test_signatures.py
+++ b/papyri/tests/test_signatures.py
@@ -156,7 +156,7 @@ def async_function_2(posonly, /, pos_or_k, pos_ok_k_d=1, *varargs, **varkwargs):
 @add
 def generator_function_3(posonly, /, pos_or_k, pos_ok_k_d=1, *varargs, **varkwargs):
     """{
-      "kind": "function",
+      "kind": "generator function",
       "parameters": [
         {
           "annotation": {
@@ -226,7 +226,7 @@ async def async_generator_function_4(
     posonly, /, pos_or_k, pos_ok_k_d=1, *varargs, **varkwargs
 ):
     """{
-      "kind": "function",
+      "kind": "async_generator function",
       "parameters": [
         {
           "annotation": {
@@ -289,6 +289,76 @@ async def async_generator_function_4(
       "type": "SignatureNode"
     }"""
     yield
+
+
+@add
+async def coroutine_function_5(
+    posonly, /, pos_or_k, pos_ok_k_d=1, *varargs, **varkwargs
+):
+    """{
+      "kind": "coroutine function",
+      "parameters": [
+        {
+          "annotation": {
+            "type": "Empty"
+          },
+          "default": {
+            "type": "Empty"
+          },
+          "kind": "POSITIONAL_ONLY",
+          "name": "posonly",
+          "type": "ParameterNode"
+        },
+        {
+          "annotation": {
+            "type": "Empty"
+          },
+          "default": {
+            "type": "Empty"
+          },
+          "kind": "POSITIONAL_OR_KEYWORD",
+          "name": "pos_or_k",
+          "type": "ParameterNode"
+        },
+        {
+          "annotation": {
+            "type": "Empty"
+          },
+          "default": {
+            "data": "1",
+            "type": "str"
+          },
+          "kind": "POSITIONAL_OR_KEYWORD",
+          "name": "pos_ok_k_d",
+          "type": "ParameterNode"
+        },
+        {
+          "annotation": {
+            "type": "Empty"
+          },
+          "default": {
+            "type": "Empty"
+          },
+          "kind": "VAR_POSITIONAL",
+          "name": "varargs",
+          "type": "ParameterNode"
+        },
+        {
+          "annotation": {
+            "type": "Empty"
+          },
+          "default": {
+            "type": "Empty"
+          },
+          "kind": "VAR_KEYWORD",
+          "name": "varkwargs",
+          "type": "ParameterNode"
+        }
+      ],
+      "return_annotation": {"type": "Empty"},
+      "type": "SignatureNode"
+    }"""
+    pass
 
 
 @add


### PR DESCRIPTION
Also adds a test for a generator function.

Previously, different kinds of functions were not detected as the "function" condition was short-circuiting the cases. This is a first pass for allowing more details in this metadata.

Addresses (but doesn't close) #301 