### PR TITLE
Set up tree-sitter-rst as submodule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,4 @@ build
 test.dat
 test.npy
 test.out
-tree-sitter-rst/
+

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "tree-sitter-rst"]
+	path = tree-sitter-rst
+	url = https://github.com/stsewd/tree-sitter-rst.git

--- a/Readme.md
+++ b/Readme.md
@@ -125,10 +125,7 @@ pip install -e .
 Some functionality requires ``tree_sitter_rst``. To build the TreeSitter rst parser:
 
 ```bash
-$ git clone https://github.com/stsewd/tree-sitter-rst
-$ cd tree-sitter-rst
-$ git checkout 3fc88d2097bc854ab6bf70c52b3c482849cf8e8f
-$ cd -
+$ git submodule update --init
 $ papyri build-parser
 ```
 


### PR DESCRIPTION
The biggest advantage here is that a user doesn't need to manually check the correct commit anymore, as this is already pre-set in the submodule set up.

Addresses #171 