### PR TITLE
Don't store a file for dynamically generated item.

### DIFF
--- a/papyri/gen.py
+++ b/papyri/gen.py
@@ -1440,7 +1440,7 @@ class Gen:
     def _transform_2(self, blob: DocBlob, target_item, qa: str) -> DocBlob:
         # try to find relative path WRT site package.
         # will not work for dev install. Maybe an option to set the root location ?
-        item_file = find_file(target_item)
+        item_file: Optional[str] = find_file(target_item)
         if item_file is not None and item_file.endswith("<string>"):
             # dynamically generated object (like dataclass __eq__ method
             item_file = None

--- a/papyri/gen.py
+++ b/papyri/gen.py
@@ -1446,9 +1446,12 @@ class Gen:
             item_file = None
         r = qa.split(".")[0]
         if item_file is not None:
+            # TODO: find a better way to get a relative path with respect to the
+            # root of the package ?
             for s in SITE_PACKAGE + [
                 os.path.expanduser(f"~/dev/{r}/"),
                 os.path.expanduser("~"),
+                os.getcwd(),
             ]:
                 if item_file.startswith(s):
                     item_file = item_file[len(s) :]

--- a/papyri/gen.py
+++ b/papyri/gen.py
@@ -1441,6 +1441,9 @@ class Gen:
         # try to find relative path WRT site package.
         # will not work for dev install. Maybe an option to set the root location ?
         item_file = find_file(target_item)
+        if item_file is not None and item_file.endswith("<string>"):
+            # dynamically generated object (like dataclass __eq__ method
+            item_file = None
         r = qa.split(".")[0]
         if item_file is not None:
             for s in SITE_PACKAGE + [
@@ -1449,7 +1452,6 @@ class Gen:
             ]:
                 if item_file.startswith(s):
                     item_file = item_file[len(s) :]
-
         blob.item_file = item_file
         if item_file is None:
             if type(target_item).__name__ in (

--- a/papyri/tests/test_gen.py
+++ b/papyri/tests/test_gen.py
@@ -180,8 +180,8 @@ def test_self_2():
     assert g.data["papyri.take2:RefInfo.__eq__"].to_dict()["item_file"] is None
 
 
-@pytest.mark.knownfail()
-def test_self_2():
+@pytest.mark.xfail()
+def test_self_3():
     # same as previous, but == fails on CI, to fix.
     from papyri.gen import Gen, Config
 

--- a/papyri/tests/test_gen.py
+++ b/papyri/tests/test_gen.py
@@ -172,5 +172,22 @@ def test_self_2():
         == "dask"
     )
 
-    assert g.data["papyri.take2:RefInfo"].to_dict()["item_file"] == "papyri/take2.py"
+    assert (
+        g.data["papyri.take2:RefInfo"]
+        .to_dict()["item_file"]
+        .endswith("papyri/take2.py")
+    )
     assert g.data["papyri.take2:RefInfo.__eq__"].to_dict()["item_file"] is None
+
+
+@pytest.mark.knownfail()
+def test_self_2():
+    # same as previous, but == fails on CI, to fix.
+    from papyri.gen import Gen, Config
+
+    c = Config(dry_run=True, dummy_progress=True)
+    g = Gen(False, config=c)
+    g.collect_package_metadata("papyri", ".", {})
+    g.collect_api_docs("papyri", {"papyri", "papyri.take2:RefInfo"})
+
+    assert g.data["papyri.take2:RefInfo"].to_dict()["item_file"] == ("papyri/take2.py")

--- a/papyri/tests/test_gen.py
+++ b/papyri/tests/test_gen.py
@@ -162,10 +162,15 @@ def test_self_2():
     c = Config(dry_run=True, dummy_progress=True)
     g = Gen(False, config=c)
     g.collect_package_metadata("papyri", ".", {})
-    g.collect_api_docs("papyri", {"papyri"})
+    g.collect_api_docs(
+        "papyri", {"papyri", "papyri.take2:RefInfo", "papyri.take2:RefInfo.__eq__"}
+    )
     assert (
         g.data["papyri"].to_dict()["arbitrary"][4]["children"][1]["children"][0]["dt"][
             "children"
         ][0]["reference"]["module"]
         == "dask"
     )
+
+    assert g.data["papyri.take2:RefInfo"].to_dict()["item_file"] == "papyri/take2.py"
+    assert g.data["papyri.take2:RefInfo.__eq__"].to_dict()["item_file"] is None


### PR DESCRIPTION
We try to detect where a item was define, sometime methods/objects are dynamically defined.

When this is the case, we get back a file that contain `<string>` in it's name. When that's the case we store `None` instead.

I'm wondering if we should store something else, as `None` also mean we were not able to find what the source was...