### PR TITLE
Misc Ascii and browser fixes.

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -107,7 +107,7 @@ jobs:
     - name: Test with pytest
       run: |
         pip install scipy dask
-        pytest --cov=papyri --cov-append
+        pytest --cov=papyri --cov-append -m "not postingest"
         ls -al
     - uses: actions/download-artifact@v3
       with:
@@ -121,6 +121,9 @@ jobs:
     - name: Ingest
       run: |
         coverage run -a -m papyri install ~/.papyri/data/*.zip
+    - name: Test with pytest postintest
+      run: |
+        pytest -m "postingest"
     - name: Relink
       run: |
         coverage run -a -m papyri relink

--- a/papyri/__init__.py
+++ b/papyri/__init__.py
@@ -518,8 +518,8 @@ def drop():
 
 
 @app.command()
-def ascii(name: str, color:bool=True):
-    #_intro()
+def ascii(name: str, color: bool = True):
+    # _intro()
     import trio
 
     from .render import ascii_render

--- a/papyri/__init__.py
+++ b/papyri/__init__.py
@@ -518,13 +518,16 @@ def drop():
 
 
 @app.command()
-def ascii(name: str):
-    _intro()
+def ascii(name: str, color:bool=True):
+    #_intro()
     import trio
 
     from .render import ascii_render
 
-    trio.run(ascii_render, name)
+    async def _():
+        await ascii_render(name, color=color)
+
+    trio.run(_)
 
 
 @app.command()

--- a/papyri/browser.py
+++ b/papyri/browser.py
@@ -47,6 +47,9 @@ class Link:
         self.text = text
         self.cb = cb
 
+    def selectable(self):
+        return True
+
 
 class TextWithLink(urwid.Text):
     # _selectable = True
@@ -292,7 +295,7 @@ class Renderer:
             c = converter()
 
             return ("math", c.convert(cont))
-        return ("directive", f"{d.domain}:{d.role}:`{cont}`")
+        return Text(("directive", f"{d.domain}:{d.role}:`{cont}`"))
 
     def render_Example(self, ex):
         acc = []
@@ -307,7 +310,7 @@ class Renderer:
 
     def render_Link(self, link):
         if link.reference.kind == "local":
-            return ("local", link.value)
+            return Text(("local", link.value))
         return Link("link", link.value, lambda: self.cb(link.reference))
 
     def render_BlockQuote(self, quote):
@@ -315,7 +318,7 @@ class Renderer:
             urwid.Pile([self.render(c) for c in quote.children]), left=4, right=4
         )
 
-    def render_Admonition(self, adm):
+    def render_MAdmonition(self, adm):
         kind = adm.kind
         title = (f"{kind} : {adm.title}",)
         if kind == "versionchanged":
@@ -331,6 +334,13 @@ class Renderer:
                 title_align="left",
             ),
         )
+
+    def render_MText(self, text):
+        return urwid.Text(text.value)
+
+    def render_MParagraph(self, paragraph):
+        stuff = [self.render(c) for c in paragraph.children]
+        return urwid.Pile(stuff)
 
     def render_BlockMath(self, math):
         from flatlatex import converter

--- a/papyri/gen.py
+++ b/papyri/gen.py
@@ -33,10 +33,7 @@ from typing import Any, Dict, FrozenSet, List, MutableMapping, Optional, Sequenc
 
 import jedi
 
-try:
-    import tomllib
-except ModuleNotFoundError:
-    import tomli as tomllib
+import tomllib
 import tomli_w
 from IPython.core.oinspect import find_file
 from IPython.utils.path import compress_user
@@ -1993,7 +1990,9 @@ class Gen:
                         "error with %s %s", qa, list(ecollector._errors.keys())
                     )
                 else:
-                    self.log.info("only expected error with %s", qa)
+                    self.log.info(
+                        "only expected error with %s, %s", qa, ecollector._errors.keys()
+                    )
                 continue
 
             try:

--- a/papyri/render.py
+++ b/papyri/render.py
@@ -68,7 +68,7 @@ def minify(s: str) -> str:
 
 
 def unreachable(*obj):
-    return str(obj[1])
+    return str(obj)
     assert False, f"Unreachable: {obj=}"
 
 
@@ -1200,6 +1200,18 @@ def _ascii_env():
     env.globals["len"] = len
     env.globals["unreachable"] = unreachable
     env.globals["sidebar"] = False
+
+    env.globals["bold"] = lambda x: f"\x1b[1;m{x}\x1b[0;m"
+    env.globals["underline"] = lambda x: f"\x1b[4;m{x}\x1b[0;m"
+    env.globals["black"] = lambda x: f"\x1b[30;m{x}\x1b[0;m"
+    env.globals["red"] = lambda x: f"\x1b[31;m{x}\x1b[0;m"
+    env.globals["green"] = lambda x: f"\x1b[32;m{x}\x1b[0;m"
+    env.globals["yellow"] = lambda x: f"\x1b[33;m{x}\x1b[0;m"
+    env.globals["blue"] = lambda x: f"\x1b[34;m{x}\x1b[0;m"
+    env.globals["magenta"] = lambda x: f"\x1b[35;m{x}\x1b[0;m"
+    env.globals["cyan"] = lambda x: f"\x1b[36;m{x}\x1b[0;m"
+    env.globals["white"] = lambda x: f"\x1b[37;m{x}\x1b[0;m"
+
     try:
         c = converter()
 
@@ -1245,6 +1257,7 @@ async def ascii_render(name, store=None):
     key = next(iter(gstore.glob((None, None, "module", name))))
 
     env, template = _ascii_env()
+
     builtins.print(await _ascii_render(key, gstore, env=env, template=template))
 
 

--- a/papyri/render.py
+++ b/papyri/render.py
@@ -1220,7 +1220,7 @@ def _ascii_env(color=True):
         ("cyan", 36),
         ("white", 37),
     ]:
-        env.globals[control] = partial(esc, value) if color else lambda x:x
+        env.globals[control] = partial(esc, value) if color else lambda x: x
 
     try:
         c = converter()

--- a/papyri/render.py
+++ b/papyri/render.py
@@ -1262,11 +1262,11 @@ async def _ascii_render(key: Key, store: GraphStore, *, env, template):
     )
 
 
-async def ascii_render(name, store=None):
+async def ascii_render(name, store=None, color=True):
     gstore = GraphStore(ingest_dir, {})
     key = next(iter(gstore.glob((None, None, "module", name))))
 
-    env, template = _ascii_env()
+    env, template = _ascii_env(color=color)
 
     builtins.print(await _ascii_render(key, gstore, env=env, template=template))
 

--- a/papyri/render.py
+++ b/papyri/render.py
@@ -1200,6 +1200,8 @@ def _ascii_env():
     env.globals["len"] = len
     env.globals["unreachable"] = unreachable
     env.globals["sidebar"] = False
+    env.globals["str"] = str
+    env.filters["pad"] = lambda ss:'│'+'\n│'.join([x.strip() for x in ss.split('\n')])
 
     env.globals["bold"] = lambda x: f"\x1b[1;m{x}\x1b[0;m"
     env.globals["underline"] = lambda x: f"\x1b[4;m{x}\x1b[0;m"

--- a/papyri/render.py
+++ b/papyri/render.py
@@ -1201,7 +1201,9 @@ def _ascii_env():
     env.globals["unreachable"] = unreachable
     env.globals["sidebar"] = False
     env.globals["str"] = str
-    env.filters["pad"] = lambda ss:'│'+'\n│'.join([x.strip() for x in ss.split('\n')])
+    env.filters["pad"] = lambda ss: "│" + "\n│".join(
+        [x.strip() for x in ss.split("\n")]
+    )
 
     env.globals["bold"] = lambda x: f"\x1b[1;m{x}\x1b[0;m"
     env.globals["underline"] = lambda x: f"\x1b[4;m{x}\x1b[0;m"

--- a/papyri/templates/ascii.tpl.j2
+++ b/papyri/templates/ascii.tpl.j2
@@ -155,8 +155,6 @@
    {%- endif -%}
 {% endmacro -%}
 
-{{-green("green")}} refer to items within the same document, {{blue("blue")}} external {{underline("known")}} entities, {{red("red")}} entities we were not able to find and {{yellow("yellow")}} for code, and other "raw" items, typically between double backticks.
-
 {% if doc.signature %}
     |{{bold(underline(name))}}{{bold(underline(doc.signature.to_signature()))}}
 {% endif %}

--- a/papyri/templates/ascii.tpl.j2
+++ b/papyri/templates/ascii.tpl.j2
@@ -61,41 +61,53 @@
     {% endif %}
 {% endmacro %}
 
+{% macro render_list(objs) -%}
+   |{% for item in objs -%}
+   |{{- render_II(item) -}}
+   |{% endfor -%}
+{%- endmacro %}
+
 {% macro render_II(obj) -%}
-   |{% if obj.__class__.__name__ == 'Paragraph' %}
-   |   |{{block_paragraph(obj)}}
-   |{% else %}
+   |{%- if obj.__class__.__name__ == 'Paragraph' -%}
+   |   |{{- block_paragraph(obj) -}}
+   |{%- else -%}
    |{%- set type = obj.__class__.__name__ -%}
    |   |{%- if type in ('Directive', 'Link', 'Math', 'Verbatim') -%}
    |   |   |{{unreachable()}}
-   |   |{% elif type == 'MMystDirective' %}
+   |   |{% elif type == 'MMystDirective' -%}
    |   |   |{{'\n'}}{{myst_directive(obj)}}
-   |   |{% elif type == 'Verbatim' %}
+   |   |{% elif type == 'Verbatim' -%}
    |   |   |{{obj}}
-   |   |{% elif type == 'Paragraph' %}
+   |   |{% elif type == 'Paragraph' -%}
    |   |   |{{block_paragraph(obj)}}
-   |   |{% elif type == 'BlockVerbatim' %}
+   |   |{% elif type == 'BlockVerbatim' -%}
    |   |   |{{obj.value}}
-   |   |{% elif type == 'DefList' %}
+   |   |{% elif type == 'DefList' -%}
    |   |   |    {% for item in obj.children %}
    |   |   |    {{render_II(item.dt)}}
    |   |   |        {{render_II(item.dd)}}
-   |   |   |    {%endfor %}  
+   |   |   |    {%endfor %}
    |   |{% elif type == 'DefListItem' %}
    |   |    {{-block(obj)-}}
    |   |{% elif type == 'Example' %}
    |   |   |   |{{block(obj)}}
+   |   |{% elif type == 'MLink' %}
+   |   |   |{{render_list(obj.children)}}
+   |   |{% elif type == 'MText' %}
+   |   |   |{{obj.value}}
+   |   |{% elif type == 'MParagraph'  -%}
+   |   |   |{{- render_list(obj.children) -}}
    |   |{% elif type == 'Parameters' %}
-   |   |   {% for item in obj.children %}
+   |   |   {%- for item in obj.children %}
    |   |       {{ render_II(item) }}
-   |   |   {% endfor %}
+   |   |   {%- endfor %}
    |   |{% elif type == 'Section' %}
-   |   |   {% for item in obj %}
-   |   |       {{ render_II(item) }}
-   |   |   {% endfor %}
-   |   |{% else %}
-   |   |   |Some B {{type}} Not implemented yet
-   |   |    {#{{unreachable(obj)}}#}
+   |   |   {%- for item in obj %}
+   |   |       {{- render_II(item) -}}
+   |   |   {%- endfor %}
+   |   |{%- else %}
+   |   |   |Some B {{type}} Not implemented yet:
+   |   |   |{{unreachable(obj)}}
    |   |{%- endif -%}
    |{%- endif -%}
 {%- endmacro %}
@@ -106,12 +118,12 @@
    |{% endif %}
    |{% for prg in prgs %}
    |   |   |{%- for obj in prg.children -%}
-   |   |   |    {{- render_inner(obj.__class__.__name__, obj) -}} 
+   |   |   |    {{- render_inner(obj.__class__.__name__, obj) -}}
    |   |   |{%- endfor -%}
    |{%- endfor -%}
 {%- endmacro %}
 
-        
+
 {%- macro esc(val, stuff) -%}
 [{{val}};m{{stuff}}[0;m
 {%- endmacro %}
@@ -148,10 +160,8 @@
    |{{bold(section)}}
    | 
    |{% endif %}
-   |{% if section in ['Summary', 'Extended Summary', 'Notes'] %}
-   |
+   |{%- if section in ['Summary', 'Extended Summary', 'Notes'] -%}
    |     |{{render_II(doc.content[section]) | wordwrap}}
-   |
    |{% elif section in ['Signature'] %}
    |{{unreachable()}}
    |{% elif section in ['Examples'] %}

--- a/papyri/templates/ascii.tpl.j2
+++ b/papyri/templates/ascii.tpl.j2
@@ -24,30 +24,9 @@
 {%- endif -%}
 {%- endmacro %}
 {#--#}
-{% macro render_inner(type, obj) -%}
-   |{%- if type == 'Directive' -%}
-   |   |:{{blue(obj.domain)}}:{{blue(obj.role)}}:`{{blue(obj.value)}}`
-   |{%- elif type == 'Link' %}
-   |   |{% if obj.kind=='local' %}
-   |   |    {{-green(obj.value)-}}
-   |   |{% elif obj.kind=='exists' %}
-   |   |    {{-blue(obj.value)-}}
-   |   |{% elif obj.kind=='missing' %}
-   |   |    {{-unreachable(obj)}}
-   |   |{% else %}
-   |   |{% endif %}
-   |{% elif type == 'Math' %}
-   |    ${{obj.value}}$
-   |{% elif type == 'Verbatim' %}
-   |    {{-yellow(obj.text)-}}
-   |{% else %}
-   |   |Some A {{type}}
-   |{%- endif -%}
-{%- endmacro %}
-
 {% macro block_paragraph(pgr) -%}
    |{%- for c in pgr.children -%}
-   |    |{{-render_inner(c.__class__.__name__, c)-}}
+   |    |{{-render_II(c) | trim-}}
    |{%- endfor -%}
 {% endmacro %}
 
@@ -72,39 +51,67 @@
    |   |{{- block_paragraph(obj) -}}
    |{%- else -%}
    |{%- set type = obj.__class__.__name__ -%}
-   |   |{%- if type in ('Directive', 'Link', 'Math', 'Verbatim') -%}
-   |   |   |{{unreachable()}}
-   |   |{% elif type == 'MMystDirective' -%}
+   |   |{%- if type in ('Math', 'Verbatim') -%}
+   |   |   |{{unreachable(obj)}}
+   |   |{%- elif type == 'MAdmonitionTitle' -%}
+   |   |   |    ..
+   |   |   |    {%- for item in obj.children %}
+   |   |   |    |  {{render_II(item)|trim}}
+   |   |   |    {%- endfor %}{{'::\n\n'}}
+   |   |{%- elif type == 'MAdmonition' -%}{{'\n'}}
+   |   |   |    {% for item in obj.children %}
+   |   |   |    |{{render_II(item)|wordwrap|pad}}
+   |   |   |    {%endfor %}
+   |   |   |    |{{'\n'}}
+   |   |{%- elif type == 'Directive' -%}
+   |   |   |{{blue(':'+str(obj.domain)+':'+str(obj.role)+':`'+obj.value+'`')}}
+   |   |{%- elif type == 'MMystDirective' -%}
    |   |   |{{'\n'}}{{myst_directive(obj)}}
-   |   |{% elif type == 'Verbatim' -%}
+   |   |{%- elif type == 'Verbatim' -%}
    |   |   |{{obj}}
-   |   |{% elif type == 'Paragraph' -%}
+   |   |{%- elif type == 'Paragraph' -%}
    |   |   |{{block_paragraph(obj)}}
-   |   |{% elif type == 'BlockVerbatim' -%}
+   |   |{%- elif type == 'BlockVerbatim' -%}
    |   |   |{{obj.value}}
-   |   |{% elif type == 'DefList' -%}
+   |   |{%- elif type == 'DefList' -%}
    |   |   |    {% for item in obj.children %}
    |   |   |    {{render_II(item.dt)}}
    |   |   |        {{render_II(item.dd)}}
    |   |   |    {%endfor %}
-   |   |{% elif type == 'DefListItem' %}
+   |   |{%- elif type == 'DefListItem' %}
    |   |    {{-block(obj)-}}
-   |   |{% elif type == 'Example' %}
+   |   |{%- elif type == 'Example' %}
    |   |   |   |{{block(obj)}}
-   |   |{% elif type == 'MLink' %}
+   |   |{%- elif type == 'MLink' %}
    |   |   |{{render_list(obj.children)}}
-   |   |{% elif type == 'MText' %}
+   |   |{%- elif type == 'MInlineCode' -%}
+   |   |   |{{bold(obj.value)}}
+   |   |{%- elif type == 'MText' -%}
    |   |   |{{obj.value}}
-   |   |{% elif type == 'MParagraph'  -%}
+   |   |{%- elif type == 'MParagraph'  -%}
    |   |   |{{- render_list(obj.children) -}}
    |   |{% elif type == 'Parameters' %}
    |   |   {%- for item in obj.children %}
    |   |       {{ render_II(item) }}
    |   |   {%- endfor %}
-   |   |{% elif type == 'Section' %}
+   |   |{%- elif type == 'Section' %}
    |   |   {%- for item in obj %}
    |   |       {{- render_II(item) -}}
    |   |   {%- endfor %}
+   |   |{%- elif type == 'Directive' -%}
+   |   |   |:{{blue(obj.domain)}}:{{blue(obj.role)}}:`{{blue(obj.value)}}`
+   |   |{%- elif type == 'Link' %}
+   |   |   |{% if obj.kind=='local' %}
+   |   |   |    {{-green(obj.value)-}}
+   |   |   |{% elif obj.exists %}
+   |   |   |    {{-blue(obj.value)-}}
+   |   |   |{% else %}
+   |   |   |    {{-unreachable(obj)}}
+   |   |   |{% endif %}
+   |   |{% elif type == 'Math' %}
+   |   |    ${{obj.value}}$
+   |   |{% elif type == 'Verbatim' %}
+   |   |    {{-yellow(obj.text)-}}
    |   |{%- else %}
    |   |   |Some B {{type}} Not implemented yet:
    |   |   |{{unreachable(obj)}}
@@ -118,7 +125,7 @@
    |{% endif %}
    |{% for prg in prgs %}
    |   |   |{%- for obj in prg.children -%}
-   |   |   |    {{- render_inner(obj.__class__.__name__, obj) -}}
+   |   |   |    {{- render_II(obj) -}}
    |   |   |{%- endfor -%}
    |{%- endfor -%}
 {%- endmacro %}
@@ -161,7 +168,7 @@
    | 
    |{% endif %}
    |{%- if section in ['Summary', 'Extended Summary', 'Notes'] -%}
-   |     |{{render_II(doc.content[section]) | wordwrap}}
+   |     |{{render_II(doc.content[section]) | wordwrap| trim}}
    |{% elif section in ['Signature'] %}
    |{{unreachable()}}
    |{% elif section in ['Examples'] %}
@@ -193,7 +200,7 @@
    |   |   |   |    {{green(p[1])}}
    |   |   |   |{% endif %}
    |   |   |   |   {% for item in p[2] %}
-   |   |   |   |       {{render_II(item)| wordwrap | indent(width=8)}}
+   |   |   |   |        {{render_II(item)| wordwrap |trim| indent(width=8)}}
    |   |   |   |   {% endfor -%}
    |   |   |{%- endfor -%}
    |   |{%- endfor -%}
@@ -207,8 +214,8 @@
 {% if doc.see_also %}
    |{{bold("See Also")}}
    |{% for sa in doc.see_also %}
-   |     {{bold(render_inner(sa.name.__class__.__name__, sa.name))}}
-   |         {{render_paragraph(sa.descriptions) | wordwrap | indent(width=8)}}
+   |     {{bold(render_II(sa.name))}}
+   |        {{render_paragraph(sa.descriptions) | wordwrap |trim| indent(width=8)}}
    |{% endfor %}
 {% endif %}
 

--- a/papyri/templates/ascii.tpl.j2
+++ b/papyri/templates/ascii.tpl.j2
@@ -135,18 +135,6 @@
 [{{val}};m{{stuff}}[0;m
 {%- endmacro %}
 
-{% macro bold(stuff) -%}{{esc(1,stuff)}}{%- endmacro %}
-{% macro underline(stuff) -%}{{esc(4,stuff)}}{%- endmacro %}
-
-{% macro black(stuff) -%}{{esc(30,stuff)}}{%- endmacro %}
-{% macro red(stuff) -%}{{esc(31,stuff)}}{%- endmacro %}
-{% macro green(stuff) -%}{{esc(32,stuff)}}{%- endmacro %}
-{% macro yellow(stuff) -%}{{esc(33,stuff)}}{%- endmacro %}
-{% macro blue(stuff) -%}{{esc(34,stuff)}}{%- endmacro %}
-{% macro magenta(stuff) -%}{{esc(35,stuff)}}{%- endmacro %}
-{% macro cyan(stuff) -%}{{esc(36,stuff)}}{%- endmacro %}
-{% macro white(stuff) -%}{{esc(37,stuff)}}{%- endmacro %}
-
 {%- macro ref(r) -%}
    {%- if r.exists -%}
    {{-blue(r.name)-}}

--- a/papyri/tests/expected/numpy:einsum.expected
+++ b/papyri/tests/expected/numpy:einsum.expected
@@ -1,0 +1,325 @@
+
+
+
+
+einsum(subscripts, *operands, out=None, dtype=None, order=None, casting=None, optimize=None)
+
+Using the Einstein summation convention, many common multi-dimensional, linear
+algebraic array operations can be represented in a simple fashion. In Some B
+MEmphasis Not implemented yet:
+(<MEmphasis:
+   |children: [<MText:
+   |   |value: 'implicit'
+   |   |>]
+   |>,) mode :None:None:`einsum` computes these values.In Some B MEmphasis Not
+implemented yet:
+(<MEmphasis:
+   |children: [<MText:
+   |   |value: 'explicit'
+   |   |>]
+   |>,) mode, :None:None:`einsum` provides further flexibility to compute other
+array operations that might not be considered classical Einstein summation
+operations, by disabling, or forcing summation over specified subscript
+labels.See the notes and examples for clarification.
+        
+ 
+Notes
+ 
+│..  versionadded 1.6.0::
+│
+
+The Einstein summation convention can be used to compute many multi-
+dimensional, linear algebraic array operations. :None:None:`einsum` provides a
+succinct way of representing these.A non-exhaustive list of these operations,
+which can be computed by :None:None:`einsum`, is shown below along with
+examples:Some B MList Not implemented yet:
+(<MList:
+   |ordered: False
+   |start: 1
+   |spread: False
+   |children: [<MListItem:
+   |   |spread: False
+   |   |children: [<MParagraph:
+   |   |   |children: [<MText:
+   |   |   |   |value: 'Trace of an array, '
+   |   |   |   |>, <MInlineCode:
+   |   |   |   |value: 'numpy.trace'
+   |   |   |   |>, <MText:
+   |   |   |   |value: '.'
+   |   |   |   |>]
+   |   |   |>]
+   |   |>, <MListItem:
+   |   |spread: False
+   |   |children: [<MParagraph:
+   |   |   |children: [<MText:
+   |   |   |   |value: 'Return a diagonal, '
+   |   |   |   |>, <MInlineCode:
+   |   |   |   |value: 'numpy.diag'
+   |   |   |   |>, <MText:
+   |   |   |   |value: '.'
+   |   |   |   |>]
+   |   |   |>]
+   |   |>, <MListItem:
+   |   |spread: False
+   |   |children: [<MParagraph:
+   |   |   |children: [<MText:
+   |   |   |   |value: 'Array axis summations, '
+   |   |   |   |>, <MInlineCode:
+   |   |   |   |value: 'numpy.sum'
+   |   |   |   |>, <MText:
+   |   |   |   |value: '.'
+   |   |   |   |>]
+   |   |   |>]
+   |   |>, <MListItem:
+   |   |spread: False
+   |   |children: [<MParagraph:
+   |   |   |children: [<MText:
+   |   |   |   |value: 'Transpositions and permutations, '
+   |   |   |   |>, <MInlineCode:
+   |   |   |   |value: 'numpy.transpose'
+   |   |   |   |>, <MText:
+   |   |   |   |value: '.'
+   |   |   |   |>]
+   |   |   |>]
+   |   |>, <MListItem:
+   |   |spread: False
+   |   |children: [<MParagraph:
+   |   |   |children: [<MText:
+   |   |   |   |value: 'Matrix multiplication and dot product, '
+   |   |   |   |>, <MInlineCode:
+   |   |   |   |value: 'numpy.matmul'
+   |   |   |   |>, <MText:
+   |   |   |   |value: ' '
+   |   |   |   |>, <MInlineCode:
+   |   |   |   |value: 'numpy.dot'
+   |   |   |   |>, <MText:
+   |   |   |   |value: '.'
+   |   |   |   |>]
+   |   |   |>]
+   |   |>, <MListItem:
+   |   |spread: False
+   |   |children: [<MParagraph:
+   |   |   |children: [<MText:
+   |   |   |   |value: 'Vector inner and outer products, '
+   |   |   |   |>, <MInlineCode:
+   |   |   |   |value: 'numpy.inner'
+   |   |   |   |>, <MText:
+   |   |   |   |value: ' '
+   |   |   |   |>, <MInlineCode:
+   |   |   |   |value: 'numpy.outer'
+   |   |   |   |>, <MText:
+   |   |   |   |value: '.'
+   |   |   |   |>]
+   |   |   |>]
+   |   |>, <MListItem:
+   |   |spread: False
+   |   |children: [<MParagraph:
+   |   |   |children: [<MText:
+   |   |   |   |value: 'Broadcasting, element-wise and scalar multiplication, '
+   |   |   |   |>, <MInlineCode:
+   |   |   |   |value: 'numpy.multiply'
+   |   |   |   |>, <MText:
+   |   |   |   |value: '.'
+   |   |   |   |>]
+   |   |   |>]
+   |   |>, <MListItem:
+   |   |spread: False
+   |   |children: [<MParagraph:
+   |   |   |children: [<MText:
+   |   |   |   |value: 'Tensor contractions, '
+   |   |   |   |>, <MInlineCode:
+   |   |   |   |value: 'numpy.tensordot'
+   |   |   |   |>, <MText:
+   |   |   |   |value: '.'
+   |   |   |   |>]
+   |   |   |>]
+   |   |>, <MListItem:
+   |   |spread: False
+   |   |children: [<MParagraph:
+   |   |   |children: [<MText:
+   |   |   |   |value: 'Chained array operations, in efficient calculation
+order, '
+   |   |   |   |>, <MInlineCode:
+   |   |   |   |value: 'numpy.einsum_path'
+   |   |   |   |>, <MText:
+   |   |   |   |value: '.'
+   |   |   |   |>]
+   |   |   |>]
+   |   |>]
+   |>,)The subscripts string is a comma-separated list of subscript labels,
+where each label refers to a dimension of the corresponding operand. Whenever a
+label is repeated it is summed, so np.einsum('i,i', a, b) is equivalent to
+np.inner(a,b) <numpy.inner>. If a label appears only once, it is not summed, so
+np.einsum('i', a) produces a view of a with no changes. A further example
+np.einsum('ij,jk', a, b) describes traditional matrix multiplication and is
+equivalent to np.matmul(a,b) <numpy.matmul>. Repeated subscript labels in one
+operand take the diagonal. For example, np.einsum('ii', a) is equivalent to
+np.trace(a) <numpy.trace>.In Some B MEmphasis Not implemented yet:
+(<MEmphasis:
+   |children: [<MText:
+   |   |value: 'implicit mode'
+   |   |>]
+   |>,), the chosen subscripts are important since the axes of the output are
+reordered alphabetically.  This means that np.einsum('ij', a) doesn't affect a
+2D array, while np.einsum('ji', a) takes its transpose. Additionally,
+np.einsum('ij,jk', a, b) returns a matrix multiplication, while,
+np.einsum('ij,jh', a, b) returns the transpose of the multiplication since
+subscript 'h' precedes subscript 'i'.In Some B MEmphasis Not implemented yet:
+(<MEmphasis:
+   |children: [<MText:
+   |   |value: 'explicit mode'
+   |   |>]
+   |>,) the output can be directly controlled by specifying output subscript
+labels.  This requires the identifier '->' as well as the list of output
+subscript labels. This feature increases the flexibility of the function since
+summing can be disabled or forced when required. The call np.einsum('i->', a)
+is like np.sum(a, axis=-1) <numpy.sum>, and np.einsum('ii->i', a) is like
+np.diag(a) <numpy.diag>. The difference is that :None:None:`einsum` does not
+allow broadcasting by default. Additionally np.einsum('ij,jh->ih', a, b)
+directly specifies the order of the output subscript labels and therefore
+returns matrix multiplication, unlike the example above in implicit mode.To
+enable and control broadcasting, use an ellipsis.  Default NumPy-style
+broadcasting is done by adding an ellipsis to the left of each term, like
+np.einsum('...ii->...i', a). To take the trace along the first and last axes,
+you can do np.einsum('i...i', a), or to do a matrix-matrix product with the
+left-most indices instead of rightmost, one can do
+np.einsum('ij...,jk...->ik...', a, b).When there is only one operand, no axes
+are summed, and no output parameter is provided, a view into the operand is
+returned instead of a new array.  Thus, taking the diagonal as
+np.einsum('ii->i', a) produces a view (changed in version
+1.10.0).:None:None:`einsum` also provides an alternative way to provide the
+subscripts and operands as einsum(op0, sublist0, op1, sublist1, ...,
+[sublistout]). If the output shape is not provided in this format
+:None:None:`einsum` will be calculated in implicit mode, otherwise it will be
+performed explicitly. The examples below have corresponding :None:None:`einsum`
+calls with the two parameter methods.
+
+│..  versionadded 1.10.0::
+│
+
+Views returned from einsum are now writeable whenever the input array is
+writeable. For example, np.einsum('ijk...->kji...', a) will now have the same
+effect as np.swapaxes(a, 0, 2) <numpy.swapaxes> and np.einsum('ii->i', a) will
+return a writeable view of the diagonal of a 2D array.
+
+│..  versionadded 1.12.0::
+│
+
+Added the optimize argument which will optimize the contraction order of an
+einsum expression. For a contraction with three or more operands this can
+greatly increase the computational efficiency at the cost of a larger memory
+footprint during computation.Typically a 'greedy' algorithm is applied which
+empirical tests have shown returns the optimal path in the majority of cases.
+In some cases 'optimal' will return the superlative path through a more
+expensive, exhaustive search. For iterative calculations it may be advisable to
+calculate the optimal path once and reuse that path by supplying it as an
+argument. An example is given below.See numpy.einsum_path for more details.
+ 
+Parameters
+ 
+    subscripts : str
+        Specifies the subscripts for summation as comma separated list of subscript
+        labels. An implicit (classical Einstein summation) calculation is performed
+        unless the explicit indicator '->' is included as well as subscript labels of
+        the precise output form.
+    operands : list of array_like
+        These are the arrays for the operation.
+    out : ndarray, optional
+        If provided, the calculation is done into this array.
+    dtype : {data-type, None}, optional
+        If provided, forces the calculation to use the data type specified. Note that
+        you may have to also give a more liberal casting parameter to allow the
+        conversions. Default is None.
+    order : {'C', 'F', 'A', 'K'}, optional
+        Controls the memory layout of the output. 'C' means it should be C contiguous.
+        'F' means it should be Fortran contiguous, 'A' means it should be 'F' if the
+        inputs are all 'F', 'C' otherwise. 'K' means it should be as close to the
+        layout as the inputs as is possible, including arbitrarily permuted axes.
+        Default is 'K'.
+    casting : {'no', 'equiv', 'safe', 'same_kind', 'unsafe'}, optional
+        Controls what kind of data casting may occur.  Setting this to 'unsafe' is not
+        recommended, as it can adversely affect accumulations.
+        Some B MBlockquote Not implemented yet:
+        (<MBlockquote:
+           |children: [<MList:
+           |   |ordered: False
+           |   |start: 1
+           |   |spread: False
+           |   |children: [<MListItem:
+           |   |   |spread: False
+           |   |   |children: [<MParagraph:
+           |   |   |   |children: [<MText:
+           |   |   |   |   |value: "'no' means the data types should not be cast at
+        all."
+           |   |   |   |   |>]
+           |   |   |   |>]
+           |   |   |>, <MListItem:
+           |   |   |spread: False
+           |   |   |children: [<MParagraph:
+           |   |   |   |children: [<MText:
+           |   |   |   |   |value: "'equiv' means only byte-order changes are allowed."
+           |   |   |   |   |>]
+           |   |   |   |>]
+           |   |   |>, <MListItem:
+           |   |   |spread: False
+           |   |   |children: [<MParagraph:
+           |   |   |   |children: [<MText:
+           |   |   |   |   |value: "'safe' means only casts which can preserve values
+        are allowed."
+           |   |   |   |   |>]
+           |   |   |   |>]
+           |   |   |>, <MListItem:
+           |   |   |spread: False
+           |   |   |children: [<MParagraph:
+           |   |   |   |children: [<MText:
+           |   |   |   |   |value: "'same_kind' means only safe casts or casts within a
+        kind,     like float64 to float32, are allowed."
+           |   |   |   |   |>]
+           |   |   |   |>]
+           |   |   |>, <MListItem:
+           |   |   |spread: False
+           |   |   |children: [<MParagraph:
+           |   |   |   |children: [<MText:
+           |   |   |   |   |value: "'unsafe' means any data conversions may be done."
+           |   |   |   |   |>]
+           |   |   |   |>]
+           |   |   |>]
+           |   |>]
+           |>,)
+        Default is 'safe'.
+    optimize : {False, True, 'greedy', 'optimal'}, optional
+        Controls if intermediate optimization should occur. No optimization will occur
+        if False and True will default to the 'greedy' algorithm. Also accepts an
+        explicit contraction list from the np.einsum_path function. See np.einsum_path
+        for more details. Defaults to False.
+        
+ 
+Returns
+ 
+    output : ndarray
+        The calculation based on the Einstein summation convention.
+Evaluates the Einstein summation convention on the operands.
+        
+See Also
+     dot
+        
+     einops
+        similar verbose interface is provided by :None:None:`einops
+        <https://github.com/arogozhnikov/einops>` package to cover additional
+        operations: transpose, reshape/flatten, repeat/tile, squeeze/unsqueeze and
+        reductions.
+     einsum_path
+        
+     inner
+        
+     linalg.multi_dot
+        
+     opt_einsum
+        :None:None:`opt_einsum <https://optimized-einsum.readthedocs.io/en/stable/>`
+        optimizes contraction order for einsum-like expressions in backend-agnostic
+        manner.
+     outer
+        
+     tensordot
+        
+

--- a/papyri/tests/expected/numpy:einsum.expected
+++ b/papyri/tests/expected/numpy:einsum.expected
@@ -322,4 +322,3 @@ See Also
         
      tensordot
         
-

--- a/papyri/tests/expected/numpy:linspace.expected
+++ b/papyri/tests/expected/numpy:linspace.expected
@@ -1,0 +1,76 @@
+
+
+
+
+
+Returns num evenly spaced samples, calculated over the interval [`start`,
+stop].The endpoint of the interval can optionally be excluded.
+
+│..  versionchanged 1.16.0::
+│
+│Non-scalar :None:None:`start` and :None:None:`stop` are now supported.
+
+
+
+│..  versionchanged 1.20.0::
+│
+│Values are rounded towards -inf instead of 0 when an integer dtype is
+│specified. The old behavior can still be obtained with np.linspace(start,
+stop,
+│num).astype(int)
+        
+
+ 
+Parameters
+ 
+    start : array_like
+        The starting value of the sequence.
+    stop : array_like
+        The end value of the sequence, unless endpoint is set to False. In that case,
+        the sequence consists of all but the last of num + 1 evenly spaced samples, so
+        that stop is excluded.  Note that the step size changes when endpoint is False.
+    num : int, optional
+        Number of samples to generate. Default is 50. Must be non-negative.
+    endpoint : bool, optional
+        If True, stop is the last sample. Otherwise, it is not included. Default is
+        True.
+    retstep : bool, optional
+        If True, return (samples, step), where step is the spacing between samples.
+    dtype : dtype, optional
+        The type of the output array.  If dtype is not given, the data type is inferred
+        from start and stop. The inferred dtype will never be an integer;
+        :None:None:`float` is chosen even if the arguments would produce an array of
+        integers.
+        │..  versionadded 1.9.0::
+        │
+    axis : int, optional
+        The axis in the result to store the samples.  Relevant only if start or stop
+        are array-like.  By default (0), the samples will be along a new axis inserted
+        at the beginning. Use -1 to get an axis at the end.
+        │..  versionadded 1.16.0::
+        │
+        
+ 
+Returns
+ 
+    samples : ndarray
+        There are num equally spaced samples in the closed interval [start, stop] or
+        the half-open interval [start, stop) (depending on whether endpoint is True or
+        False).
+    step : float, optional
+        Only returned if retstep is True
+        Size of spacing between samples.
+Return evenly spaced numbers over a specified interval.
+        
+See Also
+     arange
+        Similar to :None:None:`linspace`, but uses a step size (instead of the number
+        of samples).
+     geomspace
+        Similar to :None:None:`linspace`, but with numbers spaced evenly on a log scale
+        (a geometric progression).
+     how-to-partition
+        ref
+     logspace
+        Similar to :None:None:`geomspace`, but with the end points specified as
+        logarithms.

--- a/papyri/tests/expected/papyri.examples
+++ b/papyri/tests/expected/papyri.examples
@@ -1,0 +1,11 @@
+
+
+
+
+
+
+        
+
+        
+To remove in the future –– papyri
+        

--- a/papyri/tests/test_ascii_expected.py
+++ b/papyri/tests/test_ascii_expected.py
@@ -3,14 +3,13 @@ Various ascii rendering test, where we compare the rendered version to an expect
 """
 
 import pytest
-import glob
 from pathlib import Path
 import trio
 from papyri.render import _ascii_env, _ascii_render, GraphStore, ingest_dir
 
 HERE = Path(__file__).parent
 
-expected = (HERE/'expected').glob('*')
+expected = (HERE / "expected").glob("*")
 
 
 def _get_result_for_name(name):
@@ -24,13 +23,11 @@ def _get_result_for_name(name):
 
     return trio.run(part)
 
-@pytest.mark.parametrize('file', expected)
+
+@pytest.mark.parametrize("file", expected)
 def test_g(file):
-
-    item = file.name[:-len('.expected')]
-    assert item == 'numpy:einsum'
-
-    from papyri.render import ingest_dir,GraphStore
+    item = file.name[: -len(".expected")]
+    assert item == "numpy:einsum"
 
     res = _get_result_for_name(item)
 
@@ -38,13 +35,10 @@ def test_g(file):
     assert expected == res
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     gstore = GraphStore(ingest_dir, {})
     for file in expected:
-        item = file.name[:-len('.expected')]
+        item = file.name[: -len(".expected")]
         key = next(iter(gstore.glob((None, None, "module", item))))
         res = _get_result_for_name(item)
         file.write_text(res)
-
-
-

--- a/papyri/tests/test_ascii_expected.py
+++ b/papyri/tests/test_ascii_expected.py
@@ -27,8 +27,6 @@ def _get_result_for_name(name):
 @pytest.mark.parametrize("file", expected)
 def test_g(file):
     item = file.name[: -len(".expected")]
-    assert item == "numpy:einsum"
-
     res = _get_result_for_name(item)
 
     expected = file.read_text()

--- a/papyri/tests/test_ascii_expected.py
+++ b/papyri/tests/test_ascii_expected.py
@@ -23,6 +23,7 @@ def _get_result_for_name(name):
 
     return trio.run(part)
 
+
 @pytest.mark.postintest
 @pytest.mark.parametrize("file", expected)
 def test_g(file):
@@ -39,5 +40,5 @@ if __name__ == "__main__":
         item = file.name[: -len(".expected")]
         key = next(iter(gstore.glob((None, None, "module", item))))
         res = _get_result_for_name(item)
-        print('regen', key)
+        print("regen", key)
         file.write_text(res)

--- a/papyri/tests/test_ascii_expected.py
+++ b/papyri/tests/test_ascii_expected.py
@@ -23,7 +23,7 @@ def _get_result_for_name(name):
 
     return trio.run(part)
 
-
+@pytest.mark.postintest
 @pytest.mark.parametrize("file", expected)
 def test_g(file):
     item = file.name[: -len(".expected")]

--- a/papyri/tests/test_ascii_expected.py
+++ b/papyri/tests/test_ascii_expected.py
@@ -24,7 +24,7 @@ def _get_result_for_name(name):
     return trio.run(part)
 
 
-@pytest.mark.postintest
+@pytest.mark.postingest
 @pytest.mark.parametrize("file", expected)
 def test_g(file):
     item = file.name[: -len(".expected")]

--- a/papyri/tests/test_ascii_expected.py
+++ b/papyri/tests/test_ascii_expected.py
@@ -1,0 +1,42 @@
+"""
+Various ascii rendering test, where we compare the rendered version to an expected file
+"""
+
+import pytest
+import glob
+from pathlib import Path
+import trio
+from papyri.render import _ascii_env, _ascii_render
+
+HERE = Path(__file__).parent
+
+expected = (HERE/'expected').glob('*')
+
+
+def _get_result_for_name(name):
+    gstore = GraphStore(ingest_dir, {})
+    key = next(iter(gstore.glob((None, None, "module", name))))
+
+    env, template = _ascii_env(color=False)
+
+    async def part():
+        return await _ascii_render(key, gstore, env=env, template=template)
+
+    return trio.run(part)
+
+@pytest.mark.parametrize('file', expected)
+def test_g(file):
+
+    item = file.name[:-len('.expected')]
+    assert item == 'numpy:einsum'
+
+    from papyri.render import ingest_dir,GraphStore
+
+    res = _get_result_for_name(item)
+
+    expected = file.read_text()
+    assert expected == res
+
+
+if __name__ == '__main__':
+

--- a/papyri/tests/test_ascii_expected.py
+++ b/papyri/tests/test_ascii_expected.py
@@ -39,4 +39,5 @@ if __name__ == "__main__":
         item = file.name[: -len(".expected")]
         key = next(iter(gstore.glob((None, None, "module", item))))
         res = _get_result_for_name(item)
+        print('regen', key)
         file.write_text(res)

--- a/papyri/tests/test_ascii_expected.py
+++ b/papyri/tests/test_ascii_expected.py
@@ -6,7 +6,7 @@ import pytest
 import glob
 from pathlib import Path
 import trio
-from papyri.render import _ascii_env, _ascii_render
+from papyri.render import _ascii_env, _ascii_render, GraphStore, ingest_dir
 
 HERE = Path(__file__).parent
 
@@ -39,4 +39,12 @@ def test_g(file):
 
 
 if __name__ == '__main__':
+    gstore = GraphStore(ingest_dir, {})
+    for file in expected:
+        item = file.name[:-len('.expected')]
+        key = next(iter(gstore.glob((None, None, "module", item))))
+        res = _get_result_for_name(item)
+        file.write_text(res)
+
+
 


### PR DESCRIPTION
This move some of the coloration outside of the templating engine, this should let us add an option to make colors optionals, and should make testing easier, as now we can have expected colorless outputs and test the codebase against it.

This also add some fixes to the urwid frontend – which still crashes in a number of places, so I'm wondering if we shoudl rewrite it using textual. One of the other current limitation with urwind is the lack of ability to reflow paragraph is they contain multiple entries.