### PR TITLE
Add textual as a renderer

### DIFF
--- a/papyri/__init__.py
+++ b/papyri/__init__.py
@@ -1,5 +1,5 @@
 """
-Papyri – in progress
+Papyri – in progress
 
 Here are a couple of documents, or docstrings that are of interest to see how
 papyri works, generally because they crashed papyri at some point during the
@@ -560,6 +560,13 @@ def browse(qualname: str):
     from papyri.browser import main as browse
 
     browse(qualname)
+
+
+@app.command()
+def textual(qualname: str):
+    from papyri.textual import main as textual
+
+    textual(qualname)
 
 
 @app.command()

--- a/papyri/browser.py
+++ b/papyri/browser.py
@@ -553,7 +553,6 @@ def main(qualname: str):
         else:
             qualname = qualname.__module__ + "." + qualname.__qualname__
 
-
     def gen_content(blob, frame):
         R = Renderer(frame, walk, gen_content, stack)
         doc = []

--- a/papyri/browser.py
+++ b/papyri/browser.py
@@ -1,33 +1,11 @@
-#!/usr/bin/env python
-#
-# Urwid tour.  It slices, it dices..
-#    Copyright (C) 2004-2011  Ian Ward
-#
-#    This library is free software; you can redistribute it and/or
-#    modify it under the terms of the GNU Lesser General Public
-#    License as published by the Free Software Foundation; either
-#    version 2.1 of the License, or (at your option) any later version.
-#
-#    This library is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-#    Lesser General Public License for more details.
-#
-#    You should have received a copy of the GNU Lesser General Public
-#    License along with this library; if not, write to the Free Software
-#    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
-#
-# Urwid web site: http://excess.org/urwid/
-
 """
-Urwid tour.  Shows many of the standard widget types and features.
+papyri browser
 """
 import sys
 from typing import List
 
 import urwid
 import urwid.raw_display
-import urwid.web_display
 
 # from there import syslogprint as LOG
 from urwid import Text
@@ -575,9 +553,6 @@ def main(qualname: str):
         else:
             qualname = qualname.__module__ + "." + qualname.__qualname__
 
-    # import json
-    # data = json.loads(file_path.read_text())
-    # data
 
     def gen_content(blob, frame):
         R = Renderer(frame, walk, gen_content, stack)
@@ -726,11 +701,7 @@ def main(qualname: str):
         ("pyg-sa", "dark green", "", "bold"),  # string brefixes like b"", u"" r""
     ]
 
-    # use appropriate Screen class
-    if urwid.web_display.is_web_request():
-        screen = urwid.web_display.Screen()
-    else:
-        screen = urwid.raw_display.Screen()
+    screen = urwid.raw_display.Screen()
     found = True
 
     def unhandled(key):
@@ -751,10 +722,6 @@ def main(qualname: str):
 
 
 def setup() -> None:
-    urwid.web_display.set_preferences("Urwid Tour")
-    # try to handle short web requests quickly
-    if urwid.web_display.handle_short_request():
-        return
     import sys
 
     target: str
@@ -764,5 +731,5 @@ def setup() -> None:
     print(res)
 
 
-if "__main__" == __name__ or urwid.web_display.is_web_request():
+if "__main__" == __name__:
     setup()

--- a/papyri/static/papyri.tcss
+++ b/papyri/static/papyri.tcss
@@ -1,0 +1,5 @@
+/* This file is used by textual mode */
+
+#body {
+    width: 100%;
+}

--- a/papyri/textual.py
+++ b/papyri/textual.py
@@ -1,0 +1,154 @@
+"""
+papyri textual
+"""
+import sys
+from typing import List
+from pathlib import Path
+
+from textual.app import App, ComposeResult, RenderResult
+from textual import events
+from textual.binding import Binding
+from textual.containers import VerticalScroll, Container
+from textual.widgets import Header, Footer, Label, Static
+from textual.widget import Widget
+
+from emoji import emojize
+
+from papyri.crosslink import RefInfo, encoder
+from papyri.config import ingest_dir
+from papyri.myst_ast import MParagraph
+
+
+class Signature(Label):
+    DEFAULT_CSS = """
+    Signature {
+        width: 100%;
+        border: solid white;
+        padding-left: 3;
+        padding-top: 1;
+        padding-bottom: 1;
+    }
+    """
+
+    def __init__(self, qualname, signature):
+        super().__init__()
+        self.qualname = qualname
+        self.signature = self.extract_Signature(signature)
+
+    def extract_Annotation(self, annotation):
+        if "Empty" in str(annotation):
+            ret_annotation = "None"
+        else:
+            ret_annotation = ("signature", annotation)
+        return ret_annotation
+
+    def extract_Parameters(self, parameters):
+        return ", ".join([f"{p.name}" for p in parameters])
+
+    def extract_Signature(self, sig):
+        if sig:
+            kind = sig.kind
+            parameters = self.extract_Parameters(sig.parameters)
+            return_annotation = self.extract_Annotation(sig.return_annotation)
+            return f"{kind} {self.qualname.replace(':', '.')}({parameters}) -> {return_annotation}"
+        else:
+            return f"{self.qualname.replace(':', '.')}()"
+
+    def render(self) -> RenderResult:
+        return self.signature
+
+
+class Body(Static):
+    def __init__(self, title=None, body=None):
+        super().__init__()
+        self.title = title
+        self.body = body
+
+    def render(self) -> RenderResult:
+        return f"{self.title}: \n {self.body}"
+
+
+class PapyriApp(App):
+    TITLE = emojize("papyri :palm_tree:")
+
+    BINDINGS = [
+        Binding(key="q", action="quit", description="Quit the app"),
+    ]
+    CSS_PATH = Path("static/papyri.tcss")
+
+    def run(self, qualname=None, blob=None, **kwargs):
+        self.qualname = qualname
+        self.blob = blob
+        super().run(**kwargs)
+
+    def compose(self) -> ComposeResult:
+        """
+        Renders the layout on screen.
+        """
+
+        if self.blob.signature:
+            signature = self.blob.signature
+        else:
+            signature = None
+        #content = str(self.blob.content)
+
+        yield Container(
+            Header(),
+            Signature(qualname=self.qualname, signature=signature),
+            VerticalScroll(
+                *[Body(title=k, body=v) for k, v in self.blob.content.items()]
+            ),
+            Footer(),
+        )
+
+    def on_key(self, event: events.Key) -> None:
+        if event.key == "q":
+            self.exit()
+
+
+def load(file_path):
+    blob = encoder.decode(file_path.read_bytes())
+    assert hasattr(blob, "arbitrary")
+    return blob
+
+
+def guess_load(qualname):
+    """
+    Try to load JSON file for this object
+    """
+    candidates = list(ingest_dir.glob(f"*/*/module/{qualname}"))
+    if candidates:
+        for file_path in candidates:
+            try:
+                blob = load(file_path)
+            except Exception as e:
+                raise ValueError(str(file_path)) from e
+    return blob
+
+
+def main(qualname: str):
+    if not isinstance(qualname, str):
+        from types import ModuleType
+
+        if isinstance(qualname, ModuleType):
+            qualname = qualname.__name__
+        else:
+            qualname = qualname.__module__ + "." + qualname.__qualname__
+
+    blob = guess_load(qualname)
+
+    app = PapyriApp()
+    app.run(qualname, blob)
+
+
+def setup() -> None:
+    import sys
+
+    target: str
+    target = sys.argv[1]
+    assert isinstance(target, str)
+    res = main(target)
+
+
+if "__main__" == __name__:
+    setup()

--- a/papyri/textual.py
+++ b/papyri/textual.py
@@ -1,8 +1,6 @@
 """
 papyri textual
 """
-import sys
-from typing import List
 from pathlib import Path
 
 from textual.app import App, ComposeResult, RenderResult
@@ -10,13 +8,11 @@ from textual import events
 from textual.binding import Binding
 from textual.containers import VerticalScroll, Container
 from textual.widgets import Header, Footer, Label, Static
-from textual.widget import Widget
 
 from emoji import emojize
 
-from papyri.crosslink import RefInfo, encoder
+from papyri.crosslink import encoder
 from papyri.config import ingest_dir
-from papyri.myst_ast import MParagraph
 
 
 class Signature(Label):
@@ -90,7 +86,7 @@ class PapyriApp(App):
             signature = self.blob.signature
         else:
             signature = None
-        #content = str(self.blob.content)
+        # content = str(self.blob.content)
 
         yield Container(
             Header(),
@@ -148,6 +144,7 @@ def setup() -> None:
     target = sys.argv[1]
     assert isinstance(target, str)
     res = main(target)
+    print(res)
 
 
 if "__main__" == __name__:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,8 @@ dependencies = [
     "matplotlib",
     "cbor2",
     "minify_html",
+    "textual",
+    "emoji",
 ]
 
 [project.scripts]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 asks
 cachetools
 click<9
+emoji
 flit
 jedi
 matplotlib
@@ -9,6 +10,7 @@ pygments
 quart-trio
 requests
 rich
+textual
 there
 tree_sitter
 typer


### PR DESCRIPTION
This is a work in progress, and the goal is to have feature-parity with `papyri browse`.

To test, do

```
$ papyri textual numpy:loadtxt
```

for example.