### PR TITLE
Make sure new line don't ends up in inline nodes.

### DIFF
--- a/papyri/__init__.py
+++ b/papyri/__init__.py
@@ -19,8 +19,8 @@ Installation
 dev install
 -----------
 
-You may need to get a modified version of numpydoc depending on the stage of development.
-
+You may need to get a modified version of numpydoc depending on the stage of
+development::
 
     git clone https://github.com/jupyter/papyri
     cd papyri
@@ -28,8 +28,8 @@ You may need to get a modified version of numpydoc depending on the stage of dev
 
 Build the TreeSitter rst parser:
 
-Some functionality require ``tree_sitter_rst``, see run ``papyri build-parser``, and CI config file on how to build the tree-sitter
-shared object locally::
+Some functionality require ``tree_sitter_rst``, see run ``papyri build-parser``,
+and CI config file on how to build the tree-sitter shared object locally::
 
     git clone https://github.com/stsewd/tree-sitter-rst
     papyri build-parser
@@ -39,8 +39,8 @@ Usage
 -----
 
 There are mostly 3 stages to run papyri, so far you need to do the 3 steps/roles
-on your local machine, but it will not be necessary once papyri is production ready.
-The three stages are:
+on your local machine, but it will not be necessary once papyri is production
+ready. The three stages are:
 
 - As a library maintainer, generate and publish papyri IRD file.
 - As a system operator, install IRD files on your system

--- a/papyri/gen.py
+++ b/papyri/gen.py
@@ -1467,7 +1467,7 @@ class Gen:
                     repr(type(target_item).__name__),
                 )
             else:
-                self.log.warn(
+                self.log.warning(
                     "Could not find source file for %s (%s) [%s], will not be able to link to it.",
                     repr(qa),
                     target_item,

--- a/papyri/take2.py
+++ b/papyri/take2.py
@@ -79,6 +79,10 @@ class Directive(Node):
     domain: Optional[str]
     role: Optional[str]
 
+    def __init__(self, value, domain, role):
+        assert "\n" not in value
+        super().__init__(value, domain, role)
+
     def __hash__(self):
         return hash((tuple(self.value), self.domain, self.role))
 

--- a/papyri/tests/test_parse.py
+++ b/papyri/tests/test_parse.py
@@ -39,6 +39,27 @@ def test_parse_space():
     )
 
 
+def test_parse_no_newline():
+    """
+    Here we test that sections of test that contain new line in the source do
+    not have new line in the output. This make it simpler to render on output
+    that respect newlines
+    """
+    data = dedent(
+        """
+    we want to make sure that `this
+    interpreted_text` not have a newline in it and that `this
+    reference`_ does not either."""
+    ).encode()
+
+    [section] = parse(data, "test_parse_space")
+    text0, directive, text1, reference, text2 = section.children[0].children
+    assert "\n" not in directive.value
+    assert directive.value == "this interpreted_text"
+    assert "\n" not in reference.value
+    assert reference.value == "this reference"
+
+
 def test_parse_reference():
     [section] = parse(
         "This is a `reference <to this>`_".encode(), "test_parse_reference"

--- a/papyri/ts.py
+++ b/papyri/ts.py
@@ -317,7 +317,9 @@ class TSVisitor:
             # we should likely have a way to handle that.
             _text = full_text
         else:
-            _text, trailing = self.as_text(node)[1:].rsplit("`", maxsplit=1)
+            _text, trailing = (
+                self.as_text(node)[1:].replace("\n", " ").rsplit("`", maxsplit=1)
+            )
             assert trailing in ("_", "__")
         return [Directive(_text, None, None)]
 
@@ -350,7 +352,7 @@ class TSVisitor:
         assert text_value.startswith("`")
         assert text_value.endswith("`")
 
-        inner_value = text_value[1:-1]
+        inner_value = text_value[1:-1].replace("\n", " ")
 
         if "`" in inner_value:
             log.info(


### PR DESCRIPTION
This makes terminal rendering a bit simpler as most terminal rendering
libraries will actually insert a new line (while html will ignore it in
most places.