### PR TITLE
Normalize Hex addresses.

### DIFF
--- a/papyri/examples.py
+++ b/papyri/examples.py
@@ -272,5 +272,8 @@ def example_3():
     """
 
 
-def annotation_with_hex_addresses(x: "<foo 0x123>" = lambda x: x):
+foo = object()
+
+
+def annotation_with_hex_addresses(x: foo = lambda x: x):  # type:ignore [valid-type]
     pass

--- a/papyri/examples.py
+++ b/papyri/examples.py
@@ -270,3 +270,7 @@ def example_3():
         This directive will be turned into a warning admonition.
 
     """
+
+
+def annotation_with_hex_addresses(x: "<foo 0x123>" = lambda x: x):
+    pass

--- a/papyri/gen.py
+++ b/papyri/gen.py
@@ -1913,7 +1913,8 @@ class Gen:
         else:
             logo = None
         module = __import__(root)
-        self.version = module.__version__
+        # TODO: xarray does not have __version__ anymore, find another logic
+        self.version = getattr(module, "__version__", "??")
 
         try:
             meta["tag"] = meta["tag"].format(version=self.version)

--- a/papyri/signature.py
+++ b/papyri/signature.py
@@ -121,12 +121,10 @@ class Signature:
             if param.annotation is inspect._empty:
                 annotation = _empty
             elif isinstance(param.annotation, str):
-                annotation = param.annotation
+                annotation = clean_hexaddress(param.annotation)
             else:
                 # TODO: Keep the original annotation object somewhere
-                annotation = clean_hexaddress(
-                    inspect.formatannotation(param.annotation)
-                )
+                annotation = inspect.formatannotation(param.annotation)
             parameters.append(
                 ParameterNode(
                     name=param.name,

--- a/papyri/signature.py
+++ b/papyri/signature.py
@@ -37,7 +37,7 @@ class ParameterNode(Node):
         return inspect.Parameter(
             name=self.name,
             kind=getattr(inspect._ParameterKind, self.kind),
-            default=inspect._empty if isinstance(self.default, Empty) else None,
+            default=inspect._empty if isinstance(self.default, Empty) else self.default,
             annotation=inspect._empty
             if isinstance(self.annotation, Empty)
             else self.annotation,
@@ -121,10 +121,12 @@ class Signature:
             if param.annotation is inspect._empty:
                 annotation = _empty
             elif isinstance(param.annotation, str):
-                annotation = clean_hexaddress(param.annotation)
+                annotation = param.annotation
             else:
                 # TODO: Keep the original annotation object somewhere
-                annotation = inspect.formatannotation(param.annotation)
+                annotation = clean_hexaddress(
+                    inspect.formatannotation(param.annotation)
+                )
             parameters.append(
                 ParameterNode(
                     name=param.name,

--- a/papyri/signature.py
+++ b/papyri/signature.py
@@ -1,4 +1,5 @@
 import inspect
+import re
 
 from dataclasses import dataclass
 from typing import List, Any, Dict, Union
@@ -53,6 +54,11 @@ class SignatureNode(Node):
 
     def to_signature(self):
         return inspect.Signature([p.to_parameter() for p in self.parameters])
+
+
+def clean_hexaddress(s):
+    new = re.sub("0x[0-9a-f]+", "0x0000", s)
+    return new
 
 
 class Signature:
@@ -118,7 +124,9 @@ class Signature:
                 annotation = param.annotation
             else:
                 # TODO: Keep the original annotation object somewhere
-                annotation = inspect.formatannotation(param.annotation)
+                annotation = clean_hexaddress(
+                    inspect.formatannotation(param.annotation)
+                )
             parameters.append(
                 ParameterNode(
                     name=param.name,
@@ -126,7 +134,7 @@ class Signature:
                     kind=param.kind.name,
                     default=_empty
                     if param.default is inspect._empty
-                    else str(param.default),
+                    else clean_hexaddress(str(param.default)),
                 )
             )
         assert isinstance(kind, str)

--- a/papyri/tests/expected/numpy:einsum.expected
+++ b/papyri/tests/expected/numpy:einsum.expected
@@ -1,5 +1,5 @@
-einsum(subscripts, *operands, out=None, dtype=None, order=None, casting=None,
-optimize=None)
+einsum(subscripts, *operands, out='None', dtype='None', order='K',
+casting='safe', optimize='False')
 ## Extended Summary
 
 Using the Einstein summation convention, many common multi-dimensional, linear

--- a/papyri/tests/expected/numpy:linspace.expected
+++ b/papyri/tests/expected/numpy:linspace.expected
@@ -1,5 +1,5 @@
-linspace(start, stop, num=None, endpoint=None, retstep=None, dtype=None,
-axis=None)
+linspace(start, stop, num='50', endpoint='True', retstep='False', dtype='None',
+axis='0')
 ## Extended Summary
 
 Returns num evenly spaced samples, calculated over the interval [`start`, stop

--- a/papyri/tests/expected/papyri.examples:annotation_with_hex_addresses.expected
+++ b/papyri/tests/expected/papyri.examples:annotation_with_hex_addresses.expected
@@ -1,0 +1,4 @@
+annotation_with_hex_addresses(x: '<foo 0x0000>' = None)
+## Summary
+
+No Docstrings

--- a/papyri/tests/expected/papyri.examples:annotation_with_hex_addresses.expected
+++ b/papyri/tests/expected/papyri.examples:annotation_with_hex_addresses.expected
@@ -1,4 +1,5 @@
-annotation_with_hex_addresses(x: '<foo 0x0000>' = None)
+annotation_with_hex_addresses(x: '<object object at 0x0000>' = '<function
+<lambda> at 0x0000>')
 ## Summary
 
 No Docstrings

--- a/papyri/tests/expected/papyri.examples:example1.expected
+++ b/papyri/tests/expected/papyri.examples:example1.expected
@@ -1,5 +1,5 @@
-example1(pos: 'int', only: 'None', /, var: 'Union', args=None, *, kwarg,
-also=None, **kwargs)
+example1(pos: 'int', only: 'None', /, var: 'Union', args='1', *, kwarg,
+also='None', **kwargs)
 ## Summary
 
 first example.


### PR DESCRIPTION
This should allow a less variable output of the gen step, which should make it easier to track changes.

Also latest version of xarray, does not have `__version__`.

Partial default value fix in signature



Currently we use an ugly way to display signature by converting "back"
into a Signature object, but we do lose some information as we have to
turn most of these into strings.

It does only affects rendering though, so I think this is ok for now