### PR TITLE
Do not allow Newline in literal inline nodes.

### DIFF
--- a/papyri/examples.py
+++ b/papyri/examples.py
@@ -20,7 +20,7 @@ heading 4
 FieldList
 ---------
 
-In my understnading FieldList should in general not happen in the final
+In my understanding FieldList should in general not happen in the final
 Documents, they are supposed to be processed by the software reading them, and
 typically appear at the beginning of directive.
 
@@ -80,7 +80,7 @@ Code (title 2)
 Math
 ----
 
-Math shoudl both work as standalone formulas that takes a block:
+Math should both work as standalone formulas that takes a block:
 
 
 .. math::
@@ -146,6 +146,15 @@ empty
 
 ----
 
+
+Various test cases
+==================
+
+This paragraph should
+contain a literal with a new line ``here->|
+|<``, in the final output it should render properly
+without the line break,
+but a space.
 
 """
 

--- a/papyri/myst_ast.py
+++ b/papyri/myst_ast.py
@@ -73,6 +73,10 @@ class MInlineCode(Node):
     # position: Any
     # data: Any
 
+    def __init__(self, value):
+        super().__init__(value)
+        assert "\n" not in value
+
 
 # class LinkReference:
 #     type = 'linkReference'

--- a/papyri/tests/expected/papyri.examples.expected
+++ b/papyri/tests/expected/papyri.examples.expected
@@ -14,7 +14,7 @@ contain plain links, or link via directives: papyri
 
 ## FieldList
 
-In my understnading FieldList should in general not happen in the final
+In my understanding FieldList should in general not happen in the final
 Documents, they are supposed to be processed by the software reading them, and
 typically appear at the beginning of directive.
 
@@ -111,7 +111,7 @@ This is a link to `Jupyter website <jupyter.org>`
   ╰────────────────────────────────────────────────────────────────────────────╯
 ## Math
 
-Math shoudl both work as standalone formulas that takes a block:
+Math should both work as standalone formulas that takes a block:
 
 
  π=3.14159
@@ -170,6 +170,11 @@ empty
 
 ────────────────────────────────────────────────────────────────────────────────
 ────────────────────────────────────────────────────────────────────────────────
+# Various test cases
+
+This paragraph should contain a literal with a new line here->| |<, in the
+final output it should render properly without the line break, but a space.
+
 ## Summary
 
 To remove in the future –– papyri.examples

--- a/papyri/ts.py
+++ b/papyri/ts.py
@@ -395,7 +395,8 @@ class TSVisitor:
 
     def visit_literal(self, node, prev_end=None):
         text = self.bytes[node.start_byte + 2 : node.end_byte - 2].decode()
-        t = MInlineCode(text)
+        assert "\n\n" not in text
+        t = MInlineCode(text.replace("\n", " "))
         # print(' '*self.depth*4, t)
         return [t]
 


### PR DESCRIPTION
When a literal span two lines, as we directly extract the bytes offsets from tree sitter, we do end up including the newline.

This make it slightly more complicated to fix in the rendering as we now need to consider newline separately in the wrapping logic.

With this we normalize newline to spaces as if the text was all written on the same line.