### PR TITLE
Fixes incorrect parsing of Warning directive

### DIFF
--- a/papyri/gen.py
+++ b/papyri/gen.py
@@ -1385,7 +1385,8 @@ class Gen:
         title_map = {}
         blbs = {}
         with self.progress() as p2:
-            task = p2.add_task("Parsing narative", total=len(files))
+            task = p2.add_task("Parsing narrative", total=len(files))
+
             for p in files:
                 p2.update(task, description=compress_user(str(p)).ljust(7))
                 p2.advance(task)
@@ -1983,9 +1984,9 @@ class Gen:
 
         if item_docstring is None and not isinstance(target_item, ModuleType):
             return None, [], api_object
-
         elif item_docstring is None and isinstance(target_item, ModuleType):
             item_docstring = """This module has no documentation"""
+
         try:
             sections = ts.parse(item_docstring.encode(), qa)
         except (AssertionError, NotImplementedError) as e:
@@ -2063,6 +2064,7 @@ class Gen:
             )
 
         collected = {k: v for k, v in collected.items() if k not in excluded}
+
         if limit_to:
             non_existinsing = [k for k in limit_to if k not in collected]
             if non_existinsing:
@@ -2076,6 +2078,7 @@ class Gen:
             self.log.info("DEV: regenerating docs only for")
             for k, v in collected.items():
                 self.log.info(f"    {k}:{v}")
+
         aliases: Dict[FullQual, Cannonical]
         aliases, not_found = collector.compute_aliases()
         rev_aliases: Dict[Cannonical, FullQual] = {v: k for k, v in aliases.items()}

--- a/papyri/tests/test_ascii_expected.py
+++ b/papyri/tests/test_ascii_expected.py
@@ -12,6 +12,8 @@ expected = (HERE / "expected").glob("*")
 
 
 def _get_result_for_name(name):
+    # WARNING: This test only works if the papyri and numpy docs are generated and
+    # ingested first
     gstore = GraphStore(ingest_dir, {})
     key = next(iter(gstore.glob((None, None, "module", name))))
 

--- a/papyri/tests/test_parse.py
+++ b/papyri/tests/test_parse.py
@@ -1,9 +1,16 @@
 from textwrap import dedent
+from pathlib import Path
 
 import pytest
 
 from papyri import errors
-from papyri.ts import parse
+from papyri.ts import parse, Node, TSVisitor
+from tree_sitter import Language, Parser
+
+parser = Parser()
+pth = str(Path(__file__).parent.parent / "rst.so")
+RST = Language(pth, "rst")
+parser.set_language(RST)
 
 
 # @pytest.mark.xfail(strict=True)
@@ -17,7 +24,6 @@ def test_parse_space_in_directive_section():
         should raise/warn in papyri.
         It may depends on the tree-sitter rst version.
 
-
     """
     )
     pytest.raises(
@@ -27,6 +33,77 @@ def test_parse_space_in_directive_section():
         "test_parse_space_in_directive_section",
     )
 
+
+def test_parse_directive_body():
+    data1 = dedent(
+        """
+
+    .. directive:: Directive title
+
+        This directive declares a title and content in a block separated from
+        the definition by an empty new line.
+
+    """
+    )
+    data2 = dedent(
+        """
+
+    .. directive:: Directive title
+        This directive declares a title and content not separated by an empty
+        newline.
+
+    """
+    )
+
+    text1 = data1.strip("\n").encode()
+    text2 = data2.strip("\n").encode()
+
+    tree1 = parser.parse(text1)
+    tree2 = parser.parse(text2)
+
+    directive1 = Node(tree1.root_node).without_whitespace()
+    directive2 = Node(tree2.root_node).without_whitespace()
+
+    tsv1 = TSVisitor(text1, directive1, "test_parse_directive_body")
+    tsv2 = TSVisitor(text2, directive2, "test_parse_directive_body")
+
+    items1 = tsv1.visit(directive1)
+    items2 = tsv2.visit(directive2)
+
+    assert items1[0].name == "directive"
+    assert items1[0].args == "Directive title"
+    assert items1[0].options == dict()
+    assert items1[0].value == "This directive declares a title and content in a block separated from\nthe definition by an empty new line."
+    assert items1[0].children == []
+
+    assert items2[0].name == "directive"
+    assert items2[0].args == "Directive title"
+    assert items2[0].options == dict()
+    assert items2[0].value == "This directive declares a title and content not separated by an empty\nnewline."
+    assert items2[0].children == []
+
+def test_parse_warning_directive():
+    data = dedent(
+        """
+
+    .. warning:: Title
+
+        The warning directive does not admit a title.
+
+    """
+    )
+    text = data.strip("\n").encode()
+    tree = parser.parse(text)
+    directive = Node(tree.root_node)
+    tsv = TSVisitor(text, directive, "test_parse_directive_body")
+    new_node = directive.without_whitespace()
+    items = tsv.visit(new_node)
+
+    assert items[0].name == "warning"
+    assert items[0].args == ""
+    assert items[0].options == dict()
+    assert items[0].value == "Title The warning directive does not admit a title."
+    assert items[0].children == []
 
 def test_parse_space():
     [section] = parse(

--- a/papyri/tests/test_parse.py
+++ b/papyri/tests/test_parse.py
@@ -73,14 +73,21 @@ def test_parse_directive_body():
     assert items1[0].name == "directive"
     assert items1[0].args == "Directive title"
     assert items1[0].options == dict()
-    assert items1[0].value == "This directive declares a title and content in a block separated from\nthe definition by an empty new line."
+    assert (
+        items1[0].value
+        == "This directive declares a title and content in a block separated from\nthe definition by an empty new line."
+    )
     assert items1[0].children == []
 
     assert items2[0].name == "directive"
     assert items2[0].args == "Directive title"
     assert items2[0].options == dict()
-    assert items2[0].value == "This directive declares a title and content not separated by an empty\nnewline."
+    assert (
+        items2[0].value
+        == "This directive declares a title and content not separated by an empty\nnewline."
+    )
     assert items2[0].children == []
+
 
 def test_parse_warning_directive():
     data = dedent(
@@ -104,6 +111,7 @@ def test_parse_warning_directive():
     assert items[0].options == dict()
     assert items[0].value == "Title The warning directive does not admit a title."
     assert items[0].children == []
+
 
 def test_parse_space():
     [section] = parse(

--- a/papyri/tests/test_parse.py
+++ b/papyri/tests/test_parse.py
@@ -1,16 +1,9 @@
 from textwrap import dedent
-from pathlib import Path
 
 import pytest
 
 from papyri import errors
-from papyri.ts import parse, Node, TSVisitor
-from tree_sitter import Language, Parser
-
-parser = Parser()
-pth = str(Path(__file__).parent.parent / "rst.so")
-RST = Language(pth, "rst")
-parser.set_language(RST)
+from papyri.ts import parse, Node, TSVisitor, parser
 
 
 # @pytest.mark.xfail(strict=True)


### PR DESCRIPTION
The Warning directive does not admit a title, see https://docutils.sourceforge.io/docs/ref/doctree.html#warning

Also improves tests for directive parsing.

Before:
![Screenshot_20231213_075149](https://github.com/jupyter/papyri/assets/3949932/f9aabd80-a474-4818-9bab-55d2b1439f37)

After:
![Screenshot_20231218_113215](https://github.com/jupyter/papyri/assets/3949932/6bf32a07-4515-40d1-88eb-39deda221939)
