### PR TITLE
Extract url resolving out of jinja template. 

### DIFF
--- a/papyri/render.py
+++ b/papyri/render.py
@@ -420,7 +420,7 @@ class HtmlRenderer:
         return self.env.get_template("html.tpl.j2").render(
             graph=None,
             # TODO: next 2
-            backrefs=[[], []],
+            backrefs=[],
             module="*",
             doc=doc,
             parts=list({"*": []}.items()),
@@ -655,7 +655,7 @@ class HtmlRenderer:
         # Here if we have too many references we group them on where they come from.
         assert not hasattr(doc, "logo")
 
-        backrefs_ = (None, group_backrefs(backrefs, self.LR))
+        backrefs_ = group_backrefs(backrefs, self.LR)
 
         root = json.dumps(self._myst_root(doc).to_dict(), indent=2)
         try:

--- a/papyri/templates/html.tpl.j2
+++ b/papyri/templates/html.tpl.j2
@@ -12,24 +12,6 @@
 {{render_myst_json(myst_root)}}
 
 
-{% if backrefs %}
-    <h3 id='section-backrefs'>Back References</h3>
-    <p>The following pages refer to to this document either explicitly or contain code examples using this.</p>
-
-
-   {% for k,v in backrefs.items() %}
-        <h4>{{k}}</h4>
-        <details>
-            <summary>{{v | length}} Elements</summary>
-            <dl>
-            {% for r in v %}
-                <dd>{{ render_II(r) -}}</dd>
-            {% endfor %}
-            </dl>
-        </details>
-    {% endfor %}
-{% endif %}
-
 {% if graph %}
 <h3>Local connectivity graph</h3>
 <p>Hover to see nodes names; edges to Self not shown, Caped at 50 nodes.</p>

--- a/papyri/templates/html.tpl.j2
+++ b/papyri/templates/html.tpl.j2
@@ -12,13 +12,12 @@
 {{render_myst_json(myst_root)}}
 
 
-{% if backrefs[0] or backrefs[1] %}
+{% if backrefs %}
     <h3 id='section-backrefs'>Back References</h3>
     <p>The following pages refer to to this document either explicitly or contain code examples using this.</p>
 
 
-    {% if backrefs[1] is not none %}
-        {% for k,v in backrefs[1].items() %}
+   {% for k,v in backrefs.items() %}
         <h4>{{k}}</h4>
         <details>
             <summary>{{v | length}} Elements</summary>
@@ -29,7 +28,6 @@
             </dl>
         </details>
     {% endfor %}
-    {% endif%}
 {% endif %}
 
 {% if graph %}

--- a/papyri/templates/macros.tpl.j2
+++ b/papyri/templates/macros.tpl.j2
@@ -39,18 +39,10 @@
 {% macro render_II(obj) -%}
 
     {%- set type = obj.__class__.__name__ -%}
-       {% if type[0] == 'M' %}
+    {% if type[0] == 'M' %}
             {{ render_myst(obj) }}
-       {%- elif type == 'MMystDirective' -%}
-           {{ unreachable()}}
-           {{myst_directive(obj)}}
        {%- elif type == 'DefList' -%}
           {{ render_myst(obj) }}
-      {% elif type == 'Section' %}
-          {{unreachable(obj)}}
-           {% for item in obj %}
-               {{ render_II(item) }}
-           {% endfor %}
        {% elif type == 'FieldList' %}
            <dl> 
              {%- for item in obj.children %}
@@ -75,21 +67,6 @@
              {{ render_myst(obj) }}
         {%- elif type in ('Math', 'Verbatim', 'MText','MEmphasis','MInlineCode', 'MLink') -%}
             {{ render_myst(obj) }}
-       {% elif type == 'TocTree' %}
-            {{ unreachable()}}
-            {%if obj.children%}
-                <details class='toctree' open>
-                <summary><a class="toctree" href="{{url(obj.ref)}}">{{obj.title}}</a></summary>
-                  <ul>
-                   {% for c in obj.children %}
-                       <li>{{render_II(c)}}</li>
-                   {% endfor %}
-                  </ul>
-                </details>
-            {% else %}
-                <a class="toctree" href="{{url(obj.ref)}}">{{obj.title}}</a>
-            {%endif%}
-         
         {%- elif type in ['SubstitutionRef','Unimplemented','SubstitutionDef'] %}
             {{unimplemented(type, obj.__class__.__name__, obj.__dict__)}}
             <pre class='not-implemented'>{{obj}}</pre>

--- a/papyri/templates/macros.tpl.j2
+++ b/papyri/templates/macros.tpl.j2
@@ -58,19 +58,7 @@
                </dd>
                {% endfor %}
            </dl>
-       {% elif type in ['Options','Unimplemented','Comment','SubstitutionRef'] %}
-           <pre class='not-implemented'>
-            {{obj}}
-           </pre>
-        {%- elif type == 'Directive' -%}
-             <!-- In theory we should never get Raw directive in final output --!>
-             {{ render_myst(obj) }}
-        {%- elif type in ('Math', 'Verbatim', 'MText','MEmphasis','MInlineCode', 'MLink') -%}
-            {{ render_myst(obj) }}
-        {%- elif type in ['SubstitutionRef','Unimplemented','SubstitutionDef'] %}
-            {{unimplemented(type, obj.__class__.__name__, obj.__dict__)}}
-            <pre class='not-implemented'>{{obj}}</pre>
-        {%- else %}
+       {%- else %}
             {{unreachable(type, obj.__class__.__name__, obj.__dict__)}}
        {%- endif -%}
 {%- endmacro %}

--- a/papyri/templates/skeleton.tpl.j2
+++ b/papyri/templates/skeleton.tpl.j2
@@ -6,8 +6,8 @@
                 <div class="dropdown">
                 <a href={{module}}>{{module}}</a>&nbsp;/&nbsp;
                     <div class="dropdown-content">
-                            {% for link,name in parts_mods -%}
-                                <a href="{{url(link)}}">{{link.path}}</a>
+                            {% for url,name in parts_mods -%}
+                                <a href="{{url}}">{{name}}</a>
                             {% endfor %}
                      </div>
                 </div>
@@ -40,8 +40,8 @@
                         {% endif %}
                         {% if not loop.first %}
                             <div class="dropdown-content">
-                            {% for link,name in links -%}
-                                <a href="{{url(link)}}">{{name}}</a>
+                            {% for url,name in links -%}
+                                <a href="{{url}}">{{name}}</a>
                             {% endfor %}
                             </div>
                         {% endif %}


### PR DESCRIPTION
Jinja template used to to a bunch of url resolving from RefInfo. 

This was hard to profile in general. 

So we try to pull out url resolving outside of Jinja. 

With that we can also remove a bunch of unreachable template, and cache the url resolving. 

This make `papyri render` quite faster as the bottleneck rendering the navigation at the top off the page that is shared across many pages.

Hopefully this will also speedup CI. 