### PR TITLE
Fix warning directive rendering

### DIFF
--- a/papyri/tests/test_parse.py
+++ b/papyri/tests/test_parse.py
@@ -109,7 +109,10 @@ def test_parse_warning_directive():
     assert items[0].name == "warning"
     assert items[0].args == ""
     assert items[0].options == dict()
-    assert items[0].value == "Title The warning directive does not admit a title.\nJust testing now."
+    assert (
+        items[0].value
+        == "Title The warning directive does not admit a title.\nJust testing now."
+    )
     assert items[0].children == []
 
 

--- a/papyri/tests/test_parse.py
+++ b/papyri/tests/test_parse.py
@@ -95,6 +95,7 @@ def test_parse_warning_directive():
     .. warning:: Title
 
         The warning directive does not admit a title.
+        Just testing now.
 
     """
     )
@@ -108,7 +109,7 @@ def test_parse_warning_directive():
     assert items[0].name == "warning"
     assert items[0].args == ""
     assert items[0].options == dict()
-    assert items[0].value == "Title The warning directive does not admit a title."
+    assert items[0].value == "Title The warning directive does not admit a title.\nJust testing now."
     assert items[0].children == []
 
 

--- a/papyri/ts.py
+++ b/papyri/ts.py
@@ -681,7 +681,7 @@ class TSVisitor:
                 raise ValueError(f"{role} directive has no content")
 
             padding = (content_node[0].start_point[1] - _1.start_point[1]) * " "
-            content = dedent(padding + content)
+            content = dedent(padding + content).lstrip(" ")
             argument = ""
             options = []
             groups = []


### PR DESCRIPTION
I _think_ this is what we want. It does fix the rendering for the warning directive but I'm not sure why this wasn't showing up in other directives...

Closes #367 