### PR TITLE
Ensure tests run even if dask is not installed

### DIFF
--- a/papyri/tests/test_gen.py
+++ b/papyri/tests/test_gen.py
@@ -206,12 +206,21 @@ def test_self_2():
     g.collect_api_docs(
         "papyri", {"papyri", "papyri.take2:RefInfo", "papyri.take2:RefInfo.__eq__"}
     )
-    assert (
-        g.data["papyri"].to_dict()["arbitrary"][4]["children"][1]["children"][0]["dt"][
-            "children"
-        ][0]["reference"]["module"]
-        == "dask"
-    )
+    try:
+        import dask
+        assert (
+            g.data["papyri"].to_dict()["arbitrary"][4]["children"][1]["children"][0]["dt"][
+                "children"
+            ][0]["reference"]["module"]
+            == "dask"
+        )
+    except ImportError:
+        assert (
+            g.data["papyri"].to_dict()["arbitrary"][4]["children"][1]["children"][0]["dt"][
+                "children"
+            ][0]["domain"]
+            is None
+        )
 
     assert (
         g.data["papyri.take2:RefInfo"]


### PR DESCRIPTION
If dask is installed, 

```
g.data["papyri"].to_dict()["arbitrary"][4]["children"][1]["children"][0]["dt"]["children"][0]=
{
	'type': 'Link', 
	'value': 'dask.delayed', 
	'reference': 
		{
			'type': 'RefInfo', 
			'module': 'dask', 
			'version': '*', 
			'kind': 'api', 
			'path': 'dask.delayed:delayed'
		}, 
	'kind': 'module', 
	'exists': True, 
	'anchor': None
}
```

if dask is not installed, 

```
g.data["papyri"].to_dict()["arbitrary"][4]["children"][1]["children"][0]["dt"]["children"][0]=
{
	'type': 'Directive', 
	'value': 'dask.delayed', 
	'domain': None, 
	'role': None
}
```

We may also want to test the `type` here.