### PR TITLE
Introduce and IPython extension to make the ``?`` operator work.

### DIFF
--- a/papyri-lab/src/widgets.tsx
+++ b/papyri-lab/src/widgets.tsx
@@ -33,7 +33,7 @@ const PapyriComponent = (): JSX.Element => {
     navs.pop();
     const pen = navs.pop();
     if (pen !== undefined) {
-      console.log('Settgin search term', pen);
+      console.log('Setting search term', pen);
       await setSearchTerm(pen);
       console.log('... and searchg for ', pen);
       await search(pen);

--- a/papyri/__init__.py
+++ b/papyri/__init__.py
@@ -695,5 +695,28 @@ def open(qualname: str):
     webbrowser.get().open("file://" + str(path), new=1)
 
 
+def load_ipython_extension(ipython):
+    import IPython
+
+    if IPython.version_info < (8, 21):
+        # bug in IPython < 8, 21 where returning more mimetypes than just text and html override the
+        # full mimebundle.
+        print("papyri extension only works with IPython >= 8.21")
+        return
+
+    def hook(obj, oinfo):
+        from papyri.utils import full_qual
+
+        # TODO:
+        # for now just return the fully qualified name of the object,
+        # so that the frontend can later use a KernelSpy to display the right
+        # page.
+        # this is not completely sufficient, we might need to get the module version.
+        # but we can extend that later.
+        return {"qualname": full_qual(obj)}
+
+    ipython.inspector.mime_hooks["x-vendor/papyri"] = hook
+
+
 if __name__ == "__main__":
     app()


### PR DESCRIPTION
When ``?`` is used from within and IPython kernel, it will send an extra mimetype that we can listen for on the frontend to show the relevant page.