### PR TITLE
Reintroduce tree-sitter-languages.

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -46,7 +46,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements-dev.txt
-        python examples.py
         flit install --symlink
         # this is not needed if tree-sitter-languages works
         #git clone  https://github.com/stsewd/tree-sitter-rst

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -46,6 +46,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements-dev.txt
+        python examples.py
         flit install --symlink
         # this is not needed if tree-sitter-languages works
         #git clone  https://github.com/stsewd/tree-sitter-rst

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -47,11 +47,12 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r requirements-dev.txt
         flit install --symlink
-        git clone  https://github.com/stsewd/tree-sitter-rst
-        cd tree-sitter-rst
-        git checkout 3fc88d2097bc854ab6bf70c52b3c482849cf8e8f
-        cd -
-        papyri build-parser
+        # this is not needed if tree-sitter-languages works
+        #git clone  https://github.com/stsewd/tree-sitter-rst
+        #cd tree-sitter-rst
+        #git checkout 3fc88d2097bc854ab6bf70c52b3c482849cf8e8f
+        #cd -
+        #papyri build-parser
     - name: dependency tree
       run: |
         pipdeptree

--- a/example.py
+++ b/example.py
@@ -1,0 +1,3 @@
+from tree_sitter_languages import get_parser
+
+print(get_parser("rst"))

--- a/example.py
+++ b/example.py
@@ -1,3 +1,0 @@
-from tree_sitter_languages import get_parser
-
-print(get_parser("rst"))

--- a/papyri/__init__.py
+++ b/papyri/__init__.py
@@ -596,6 +596,8 @@ def build_parser():
     work on all platofrms
 
     """
+    # this is used just for dev of tree-sitter
+    return
     from tree_sitter import Language
 
     pth = Path(__file__).parent / "rst.so"

--- a/papyri/rich_render.py
+++ b/papyri/rich_render.py
@@ -21,6 +21,10 @@ from typing import TYPE_CHECKING
 
 from .myst_ast import MText
 
+import logging
+
+logger = logging.getLogger(__name__)
+
 if TYPE_CHECKING:
     from .myst_ast import MAdmonition, MAdmonitionTitle
 
@@ -162,6 +166,10 @@ class RichVisitor:
         res = [RToken(v) for v in part(node.value, " ")]
         assert res[-1].value != "\n"
         return res
+
+    def visit_MImage(self, node):
+        logger.warning("TODO: implement images")
+        return RToken("Image TODO").partition()
 
     def visit_MEmphasis(self, node):
         return self.generic_visit(node.children)

--- a/papyri/tests/expected/numpy:linspace.expected
+++ b/papyri/tests/expected/numpy:linspace.expected
@@ -6,8 +6,8 @@ Return evenly spaced numbers over a specified interval.
 
 ## Extended Summary
 
-Returns num evenly spaced samples, calculated over the interval [`start`, stop
-].
+Returns num evenly spaced samples, calculated over the interval [start, stop].
+
 
 The endpoint of the interval can optionally be excluded.
 

--- a/papyri/tree.py
+++ b/papyri/tree.py
@@ -356,6 +356,7 @@ class TreeReplacer:
                 "MComment",
                 "MInlineCode",
                 "MInlineMath",
+                "MImage",
                 "MMath",
                 "MText",
                 "MThematicBreak",

--- a/papyri/ts.py
+++ b/papyri/ts.py
@@ -1,6 +1,5 @@
 import logging
 import itertools
-from pathlib import Path
 from textwrap import dedent, indent
 from typing import List, Any, Dict
 
@@ -42,28 +41,11 @@ from .errors import (
     # VisitSubstitutionDefinitionNotImplementedError,
 )
 
+
+from tree_sitter_languages import get_parser
+
+parser = get_parser("rst")
 allowed_adorn = "=-`:.'\"~^_*+#<>"
-
-try:
-    from tree_sitter_languages import get_parser
-
-    # language = get_language('python')
-    parser = get_parser("rst")
-except ModuleNotFoundError:
-    # replace by tree-sitter-languages once it works
-    # See https://github.com/grantjenks/py-tree-sitter-languages/issues/15
-    try:
-        from tree_sitter import Language, Parser
-
-        pth = str(Path(__file__).parent / "rst.so")
-        RST = Language(pth, "rst")
-    except OSError as e:
-        raise OSError(
-            "tree-sitter-rst not found, rst parsing will not work. Please run `papyri build-parser`"
-        ) from e
-
-    parser = Parser()
-    parser.set_language(RST)
 
 log = logging.getLogger("papyri")
 

--- a/papyri/ts.py
+++ b/papyri/ts.py
@@ -4,7 +4,6 @@ from pathlib import Path
 from textwrap import dedent, indent
 from typing import List, Any, Dict
 
-from tree_sitter import Language, Parser
 
 from .myst_ast import (
     MText,
@@ -46,16 +45,25 @@ from .errors import (
 allowed_adorn = "=-`:.'\"~^_*+#<>"
 pth = str(Path(__file__).parent / "rst.so")
 
-# replace by tree-sitter-languages once it works See https://github.com/grantjenks/py-tree-sitter-languages/issues/15
 try:
-    RST = Language(pth, "rst")
-except OSError as e:
-    raise OSError(
-        "tree-sitter-rst not found, rst parsing will not work. Please run `papyri build-parser`"
-    ) from e
+    from tree_sitter_languages import get_language, get_parser
 
-parser = Parser()
-parser.set_language(RST)
+    # language = get_language('python')
+    parser = get_parser("rst")
+except ModuleNotFoundError:
+    # replace by tree-sitter-languages once it works See https://github.com/grantjenks/py-tree-sitter-languages/issues/15
+    try:
+        from tree_sitter import Language, Parser
+
+        RST = Language(pth, "rst")
+    except OSError as e:
+        raise OSError(
+            "tree-sitter-rst not found, rst parsing will not work. Please run `papyri build-parser`"
+        ) from e
+
+    parser = Parser()
+    parser.set_language(RST)
+
 log = logging.getLogger("papyri")
 
 

--- a/papyri/ts.py
+++ b/papyri/ts.py
@@ -45,11 +45,12 @@ from .errors import (
 allowed_adorn = "=-`:.'\"~^_*+#<>"
 
 try:
-    from tree_sitter_languages import get_language, get_parser
+    from tree_sitter_languages import get_parser
 
     # language = get_language('python')
     parser = get_parser("rst")
 except ModuleNotFoundError:
+    assert False
     # replace by tree-sitter-languages once it works See https://github.com/grantjenks/py-tree-sitter-languages/issues/15
     try:
         from tree_sitter import Language, Parser

--- a/papyri/ts.py
+++ b/papyri/ts.py
@@ -50,8 +50,8 @@ try:
     # language = get_language('python')
     parser = get_parser("rst")
 except ModuleNotFoundError:
-    assert False
-    # replace by tree-sitter-languages once it works See https://github.com/grantjenks/py-tree-sitter-languages/issues/15
+    # replace by tree-sitter-languages once it works
+    # See https://github.com/grantjenks/py-tree-sitter-languages/issues/15
     try:
         from tree_sitter import Language, Parser
 

--- a/papyri/ts.py
+++ b/papyri/ts.py
@@ -43,7 +43,6 @@ from .errors import (
 )
 
 allowed_adorn = "=-`:.'\"~^_*+#<>"
-pth = str(Path(__file__).parent / "rst.so")
 
 try:
     from tree_sitter_languages import get_language, get_parser
@@ -55,6 +54,7 @@ except ModuleNotFoundError:
     try:
         from tree_sitter import Language, Parser
 
+        pth = str(Path(__file__).parent / "rst.so")
         RST = Language(pth, "rst")
     except OSError as e:
         raise OSError(

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,7 +3,6 @@ pytest-cov
 flit
 matplotlib
 pytest-trio
-tree_sitter
 coverage
 jinja2==3.1.3
 pipdeptree

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,3 +10,4 @@ black
 mypy
 flake8<8
 scipy
+tree_sitter_languages

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,4 +10,3 @@ black
 mypy
 flake8<8
 scipy
-tree_sitter_languages


### PR DESCRIPTION
It seem to be active again, with proper builds, and a newer version of tree-sitter-rst. It allow to not have to do the build-parser step