### PR TITLE
WIP: Add substitution definition code and tests

### DIFF
--- a/examples/numpy.toml
+++ b/examples/numpy.toml
@@ -6,6 +6,8 @@ exclude = [
     'numpy:tensordot',
     # See https://github.com/jupyter/papyri/issues/361'
     'numpy.ma.core:MaskedArray.resize',
+    # Contain a table that messes up the substitution ref
+    'numpy:isscalar'
 ]
 
 execute_exclude_patterns = [

--- a/examples/numpy.toml
+++ b/examples/numpy.toml
@@ -90,3 +90,6 @@ docspage = 'https://numpy.org/doc/1.26/'
 [global.expected_errors]
 VisitCitationReferenceNotImplementedError = ["numpy.fft"]
 
+[global.substitution_definitions]
+version = '1.2.3'
+

--- a/examples/scipy.toml
+++ b/examples/scipy.toml
@@ -24,7 +24,14 @@ exclude = [
     "scipy.stats._continuous_distns:crystalball_gen._pdf",
     
     # assert len(tsc) in (0, 1), (tsc, data)
-    "scipy.io.matlab._mio5"
+    "scipy.io.matlab._mio5",
+
+    # non quoted ||u|| lead to substitution ref
+    "scipy.linalg._decomp_update:qr_insert",
+    "scipy.stats._ksstats:kolmogn",
+    "scipy.optimize._trustregion:BaseQuadraticSubproblem.get_boundaries_intersections",
+    "scipy.sparse.linalg._expm_multiply:LazyOperatorNormInfo.d"
+
             ]
 exclude_jedi = [
     "scipy.linalg._sketches.clarkson_woodruff_transform",

--- a/papyri/common_ast.py
+++ b/papyri/common_ast.py
@@ -81,6 +81,16 @@ class Node(Base):
         )
 
 
+class UnserializableNode(Node):
+    _dont_serialise = True
+
+    def cbor(self, encoder):
+        assert False
+
+    def to_json(self) -> bytes:
+        assert False
+
+
 TAG_MAP: Dict[Any, int] = {}
 REV_TAG_MAP: Dict[int, Any] = {}
 

--- a/papyri/common_ast.py
+++ b/papyri/common_ast.py
@@ -85,10 +85,10 @@ class UnserializableNode(Node):
     _dont_serialise = True
 
     def cbor(self, encoder):
-        assert False
+        assert False, self
 
     def to_json(self) -> bytes:
-        assert False
+        assert False, self
 
 
 TAG_MAP: Dict[Any, int] = {}

--- a/papyri/common_ast.py
+++ b/papyri/common_ast.py
@@ -90,6 +90,9 @@ class UnserializableNode(Node):
     def to_json(self) -> bytes:
         assert False, self
 
+    def to_dict(self):
+        assert False, self
+
 
 TAG_MAP: Dict[Any, int] = {}
 REV_TAG_MAP: Dict[int, Any] = {}

--- a/papyri/crosslink.py
+++ b/papyri/crosslink.py
@@ -49,7 +49,7 @@ def find_all_refs(
 
     # TODO
     # here we can't compute just the dictionary and use frozenset(....values())
-    # as we may have multiple version of lisbraries; this is something that will
+    # as we may have multiple version of libraries; this is something that will
     # need to be fixed in the long run
     known_refs = []
     ref_map = {}
@@ -160,7 +160,7 @@ class IngestedBlobs(Node):
             "Receives",
             # "Notes",
             # "Signature",
-            #'Extended Summary',
+            # "Extended Summary",
             #'References'
             #'See Also'
             #'Examples'
@@ -181,7 +181,7 @@ class IngestedBlobs(Node):
         local_refs = frozenset(flat(_local_refs))
 
         visitor = PostDVR(
-            self.qa, known_refs, local_refs, aliases, version=version, config={}
+            self.qa, known_refs, local_refs, {}, aliases, version=version, config={}
         )
         for section in ["Extended Summary", "Summary", "Notes"] + sections_:
             if section not in self.content:
@@ -313,6 +313,7 @@ class Ingester:
                 f"TBD (examples, {path}), supposed to be QA",
                 known_refs,
                 set(),
+                {},
                 aliases,
                 version=version,
                 config={},
@@ -506,6 +507,7 @@ class Ingester:
                 f"TBD, supposed to be QA relink {key}",
                 known_refs,
                 set(),
+                {},
                 aliases,
                 version="?",
             )

--- a/papyri/crosslink.py
+++ b/papyri/crosslink.py
@@ -313,8 +313,8 @@ class Ingester:
                 f"TBD (examples, {path}), supposed to be QA",
                 known_refs,
                 set(),
-                {},
-                aliases,
+                substitution_defs={},
+                aliases=aliases,
                 version=version,
                 config={},
             )

--- a/papyri/crosslink.py
+++ b/papyri/crosslink.py
@@ -444,7 +444,8 @@ class Ingester:
                 )
 
             except Exception as e:
-                raise RuntimeError(f"error writing to {path}") from e
+                e.add_note(f"error writing to {path} {key}")
+                raise
 
     def relink(self) -> None:
         gstore = self.gstore

--- a/papyri/directives.py
+++ b/papyri/directives.py
@@ -74,7 +74,10 @@ def unicode_handler(argument, options, content):
 
 
 def replace_hander(argument, options, content):
-    # likely need some checks that this is indeed a Unicode char
+    # Here we likely want to parse the content/argument and recurse.
+    # which might change slightly the API.
+    # I think here if necessary we return an unprocessedDirective,
+    # and the TSVisitor should recurs with generic_visit ?
     return [MText(argument)]
 
 

--- a/papyri/directives.py
+++ b/papyri/directives.py
@@ -68,5 +68,15 @@ def versionchanged_handler(argument, options, content):
     return admonition_helper("versionchanged", argument, options, content)
 
 
+def unicode_handler(argument, options, content):
+    # likely need some checks that this is indeed a Unicode char
+    return [MText(chr(int("0x" + argument[2:], 0)))]
+
+
+def replace_hander(argument, options, content):
+    # likely need some checks that this is indeed a Unicode char
+    return [MText(argument)]
+
+
 def deprecated_handler(argument, options, content):
     return admonition_helper("deprecated", argument, options, content)

--- a/papyri/examples.py
+++ b/papyri/examples.py
@@ -125,7 +125,18 @@ Substitutions
 
 In this paragraph: |ALIAS| Should be replaced...
 
-.. |ALIAS| replace:: '-- SUBSTITUTION works--'
+.. |ALIAS| replace:: -- SUBSTITUTION works--
+
+Substitutions should support a |WIDE|, |VARIETY|, |OF|, |REPLACEMENT|
+
+.. |WIDE| replace:: modules links like: :mod:`papyri`
+
+.. |VARIETY| replace:: text formatting with _italics_ and **bold**
+
+.. |OF| image:: inline images are likely to not work,
+
+.. |REPLACEMENT| unicode:: U+2665
+
 
 
 

--- a/papyri/examples.py
+++ b/papyri/examples.py
@@ -123,9 +123,9 @@ This is q block quote, to do, we know that Attributions are not supported right 
 Substitutions
 ~~~~~~~~~~~~~
 
-In this paragraph: |SubstitutionRef| Should be replaced...
+In this paragraph: |ALIAS| Should be replaced...
 
-.. |SubstitutionDef| replace:: ASUBSTITUTIONDEF
+.. |ALIAS| replace:: '-- SUBSTITUTION works--'
 
 
 

--- a/papyri/gen.py
+++ b/papyri/gen.py
@@ -2260,10 +2260,26 @@ class Gen:
 
             # substitution_defs: Dict[str, Union(MImage, ReplaceNode)] = {}
             substitution_defs = {}
+            sections = []
             for section in doc_blob.sections:
-                for child in doc_blob.content.get(section, []):
+                sections.append(doc_blob.content.get(section, []))
+            # arbitrary is usually raw RST that typically is a module docstring that can't be
+            # parsed by numpydoc
+            sections.extend(arbitrary)
+            for section in sections:
+                for child in section:
                     if isinstance(child, SubstitutionDef):
+                        if child.value in substitution_defs:
+                            self.log.warn(
+                                "The same substitution definition was found twice: %s",
+                                child.value,
+                            )
                         substitution_defs[child.value] = child.children
+
+            if substitution_defs:
+                self.log.debug(
+                    "Found substitution def for %s : %s", qa, substitution_defs
+                )
 
             # def flat(l) -> List[str]:
             #    return [y for x in l for y in x]

--- a/papyri/gen.py
+++ b/papyri/gen.py
@@ -1512,7 +1512,11 @@ class Gen:
 
                 blbs[key] = blob
         for k, b in blbs.items():
-            self.docs[k] = b.to_json()
+            try:
+                self.docs[k] = b.to_json()
+            except Exception as e:
+                e.add_note(f"serializing {k}")
+                raise
 
         self._doctree = {"tree": make_tree(trees), "titles": title_map}
 

--- a/papyri/gen.py
+++ b/papyri/gen.py
@@ -1411,7 +1411,7 @@ class Gen:
         # TODO fix this if plt.close not called and still a lingering figure.
         fig_managers = _pylab_helpers.Gcf.get_all_fig_managers()
         if len(fig_managers) != 0:
-            self.log.debug(f"Unclosed figures in %s!!", qa)
+            self.log.debug("Unclosed figures in %s!!", qa)
             plt.close("all")
 
         return processed_example_data(example_section_data), doctest_runner.figs

--- a/papyri/myst_ast.py
+++ b/papyri/myst_ast.py
@@ -104,7 +104,7 @@ class MInlineCode(Node):
 @register(4045)
 class MParagraph(Node):
     type = "paragraph"
-    children: List[Union["PhrasingContent", "take2.MUnimpl"]]
+    children: List[Union["PhrasingContent", "take2.MUnimpl", "MImage"]]
     # position: Any
     # data: Any
 
@@ -266,6 +266,18 @@ class MRoot(Node):
             MImage,
         ]
     ]
+
+
+class ReplaceNode(Node):
+    # We may want to return links too.
+    type = "replace"
+    value: str
+    text: str
+    # children: Union[
+    #     MText,
+    #     MInlineCode,
+    #     MInlineMath,
+    # ]
 
 
 StaticPhrasingContent = Union[

--- a/papyri/myst_ast.py
+++ b/papyri/myst_ast.py
@@ -263,11 +263,7 @@ class ReplaceNode(Node):
     type = "replace"
     value: str
     text: str
-    # children: Union[
-    #     MText,
-    #     MInlineCode,
-    #     MInlineMath,
-    # ]
+    children: List[Node]
 
 
 StaticPhrasingContent = Union[

--- a/papyri/myst_ast.py
+++ b/papyri/myst_ast.py
@@ -4,7 +4,7 @@ An attempt to create AST from MyST spec.
 
 from typing import List, Union, Optional, Dict
 
-from .common_ast import Node, register
+from .common_ast import Node, register, UnserializableNode
 
 from . import take2
 from . import signature
@@ -150,16 +150,6 @@ class MMystDirective(Node):
     @classmethod
     def from_unprocessed(cls, up):
         return cls(up.name, up.args, up.options, up.value, up.children)
-
-
-class UnserializableNode(Node):
-    _dont_serialise = True
-
-    def cbor(self, encoder):
-        assert False
-
-    def to_json(self) -> bytes:
-        assert False
 
 
 class UnprocessedDirective(UnserializableNode):

--- a/papyri/myst_serialiser.py
+++ b/papyri/myst_serialiser.py
@@ -17,6 +17,9 @@ base_types = {int, str, bool, type(None)}
 
 
 def serialize(instance, annotation):
+    assert not getattr(
+        instance, "_dont_serialise", None
+    ), f"Should not have to serialize {instance}"
     try:
         if annotation in base_types:
             # print("BASE", instance)

--- a/papyri/take2.py
+++ b/papyri/take2.py
@@ -69,6 +69,10 @@ from .miniserde import get_type_hints
 
 from .utils import dedent_but_first
 
+import logging
+
+log = logging.getLogger(__file__)
+
 
 register(tuple)(4444)
 
@@ -184,14 +188,20 @@ class SubstitutionDef(UnserializableNode):
             self.children = [MImage(url=children[0].args, alt="")]
         elif children[0].name == "replace":
             assert len(children) == 1
-            self.children = [ReplaceNode(value=self.value, text=children[0].args)]
+            self.children = [
+                ReplaceNode(value=self.value, text=children[0].args, children=children)
+            ]
         else:
-            raise NotImplementedError("Substitution def not implemented for ", children)
+            self.children = [
+                ReplaceNode(value=self.value, text=children[0].args, children=children)
+            ]
+            # breakpoint()
+            # raise NotImplementedError("Substitution def not implemented for ", children)
 
 
 class SubstitutionRef(UnserializableNode):
     """
-    This will be in the for |XXX|, and need to be replaced.
+    This will be in the for \|XXX\|, and need to be replaced.
     """
 
     value: str

--- a/papyri/take2.py
+++ b/papyri/take2.py
@@ -64,7 +64,7 @@ from typing import Any, List, Optional, Union
 import cbor2
 from there import print
 
-from .common_ast import Node, REV_TAG_MAP, register
+from .common_ast import Node, REV_TAG_MAP, register, UnserializableNode
 from .miniserde import get_type_hints
 
 from .utils import dedent_but_first
@@ -157,8 +157,7 @@ class Leaf(Node):
     value: str
 
 
-@register(4027)
-class SubstitutionDef(Node):
+class SubstitutionDef(UnserializableNode):
     """
     A Substitution Definition should be in the form of
 
@@ -181,20 +180,24 @@ class SubstitutionDef(Node):
         assert isinstance(children[0], UnprocessedDirective)
 
         if children[0].name == "image":
+            assert len(children) == 1
             self.children = [MImage(url=children[0].args, alt="")]
         elif children[0].name == "replace":
+            assert len(children) == 1
             self.children = [ReplaceNode(value=self.value, text=children[0].args)]
         else:
-            raise NotImplementedError
+            raise NotImplementedError("Substitution def not implemented for ", children)
 
 
-@register(4041)
-class SubstitutionRef(Leaf):
+class SubstitutionRef(UnserializableNode):
     """
     This will be in the for |XXX|, and need to be replaced.
     """
 
     value: str
+
+    def __init__(self, value):
+        self.value = value
 
 
 @register(4018)

--- a/papyri/take2.py
+++ b/papyri/take2.py
@@ -159,14 +159,33 @@ class Leaf(Node):
 
 @register(4027)
 class SubstitutionDef(Node):
+    """
+    A Substitution Definition should be in the form of
+
+    .. raw:: rst
+
+        .. |value| inline_directive:: text to be inserted
+
+    Currently, the inline_directive can only be ``replace`` or ``image``. In the
+    future, we want to support any inline directives, including custom
+    user-defined directives.
+    """
+
     value: str
-    children: List[Union[MMystDirective, UnprocessedDirective]]
+    children: List[Union[ReplaceNode, MImage]]
 
     def __init__(self, value, children):
         self.value = value
         assert isinstance(children, list)
-        self.children = children
-        pass
+        assert len(children) == 1
+        assert isinstance(children[0], UnprocessedDirective)
+
+        if children[0].name == "image":
+            self.children = [MImage(url=children[0].args, alt="")]
+        elif children[0].name == "replace":
+            self.children = [ReplaceNode(value=self.value, text=children[0].args)]
+        else:
+            raise NotImplementedError
 
 
 @register(4041)
@@ -201,6 +220,8 @@ from .myst_ast import (
     MBlockquote,
     MTarget,
     MThematicBreak,
+    MImage,
+    ReplaceNode,
 )
 
 

--- a/papyri/take2.py
+++ b/papyri/take2.py
@@ -201,7 +201,7 @@ class SubstitutionDef(UnserializableNode):
 
 class SubstitutionRef(UnserializableNode):
     """
-    This will be in the for \|XXX\|, and need to be replaced.
+    This will be in the for \\|XXX\\|, and need to be replaced.
     """
 
     value: str

--- a/papyri/take2.py
+++ b/papyri/take2.py
@@ -209,6 +209,9 @@ class SubstitutionRef(UnserializableNode):
     def __init__(self, value):
         self.value = value
 
+    def to_json(self):
+        assert False
+
 
 @register(4018)
 class Unimplemented(Node):

--- a/papyri/take2.py
+++ b/papyri/take2.py
@@ -587,7 +587,7 @@ class SeeAlsoItem(Node):
     name: Link
 
     # TODO: Chck why we hav a Union Here, and if we have only Paragraphs, remove the union.
-    descriptions: List[Union[MParagraph]]
+    descriptions: List[Union[MParagraph, MComment]]
     # there are a few case when the lhs is `:func:something`... in scipy.
     type: Optional[str]
 

--- a/papyri/take2.py
+++ b/papyri/take2.py
@@ -207,6 +207,8 @@ class SubstitutionRef(UnserializableNode):
     value: str
 
     def __init__(self, value):
+        assert value.startswith("|")
+        assert value.endswith("|")
         self.value = value
 
     def to_json(self):

--- a/papyri/tests/expected/papyri.examples.expected
+++ b/papyri/tests/expected/papyri.examples.expected
@@ -142,27 +142,9 @@ now.
 
 ### Substitutions
 
-In this paragraph:
-{
-  "type": "SubstitutionRef",
-  "value": "|SubstitutionRef|"
-} Should be
-replaced...
+In this paragraph: ASUBSTITUTIONDEF Should be replaced...
 
-{
-  "type": "SubstitutionDef",
-  "value": "|SubstitutionDef|",
-  "children": [
-    {
-      "type": "mystDirective",
-      "name": "replace",
-      "args": "ASUBSTITUTIONDEF",
-      "options": {},
-      "value": "",
-      "children": []
-    }
-  ]
-}## Quotes
+## Quotes
 
 Quotes are not implemented yet in the parser, this section below will appear
 empty

--- a/papyri/tests/test_parse.py
+++ b/papyri/tests/test_parse.py
@@ -156,3 +156,39 @@ def test_parse_reference():
     [text, reference] = paragraph.children
     assert reference.value == "reference <to this>"
     assert text.value == "This is a "
+
+
+def test_parse_substitution_definition():
+    data1 = dedent(
+        """
+    A substitution definition block contains an embedded inline-compatible
+    directive (without the leading ".. "), such as "image" or "replace". For
+    example, the |biohazard| symbol must be used on containers used to dispose
+    of medical waste.
+
+    .. |biohazard| image :: https://upload.wikimedia.org/wikipedia/commons/c/c0/Biohazard_symbol.svg
+    """
+    )
+    data2 = dedent(
+        """
+    A substitution definition block contains an embedded inline-compatible
+    directive (without the leading ".. "), such as "image" or "replace". For
+    example, the |biohazard| symbol must be used on containers used to dispose
+    of medical waste.
+
+    .. |biohazard| replace :: **biohazard.png**
+    """
+    )
+    [section1] = parse(data1.encode(), "test_parse_substitution_definition")
+    [_, subsdef1] = section1.children
+    [node1] = subsdef1.children
+    [section2] = parse(data2.encode(), "test_parse_substitution_definition")
+    [_, subsdef2] = section2.children
+    [node2] = subsdef2.children
+    assert subsdef1.value == "|biohazard|"
+    assert node1.type == "image"
+    assert node1.url == "https://upload.wikimedia.org/wikipedia/commons/c/c0/Biohazard_symbol.svg"
+    assert node1.alt == ""
+    assert subsdef2.value == "|biohazard|"
+    assert node2.type == "replace"
+    assert node2.text == "**biohazard.png**"

--- a/papyri/tests/test_parse.py
+++ b/papyri/tests/test_parse.py
@@ -187,7 +187,10 @@ def test_parse_substitution_definition():
     [node2] = subsdef2.children
     assert subsdef1.value == "|biohazard|"
     assert node1.type == "image"
-    assert node1.url == "https://upload.wikimedia.org/wikipedia/commons/c/c0/Biohazard_symbol.svg"
+    assert (
+        node1.url
+        == "https://upload.wikimedia.org/wikipedia/commons/c/c0/Biohazard_symbol.svg"
+    )
     assert node1.alt == ""
     assert subsdef2.value == "|biohazard|"
     assert node2.type == "replace"

--- a/papyri/tests/utils.py
+++ b/papyri/tests/utils.py
@@ -25,6 +25,7 @@ def _process(sample: Path):
         str(sample),
         frozenset(),
         local_refs=set(),
+        substitution_defs={},
         aliases={},
         version="TestSuite",
         config={},

--- a/papyri/tree.py
+++ b/papyri/tree.py
@@ -692,6 +692,7 @@ class DirectiveVisiter(TreeReplacer):
         This node should be removed since the actual reference has already been
         resolved.
         """
+        log.warning("discard substitution node %s", node)
         return []
 
     def replace_SubstitutionRef(self, directive):
@@ -700,15 +701,17 @@ class DirectiveVisiter(TreeReplacer):
         # an image (from the image directive.)
         if directive.value in self.substitution_defs:
             if isinstance(self.substitution_defs[directive.value][0], ReplaceNode):
-                return [MText(self.substitution_defs[directive.value][0].text)]
+                return self.substitution_defs[directive.value][0].children
             elif isinstance(self.substitution_defs[directive.value][0], MImage):
                 return [self.substitution_defs[directive.value][0]]
             else:
                 raise NotImplementedError(
-                    f"SubstitutionDef for custom inline directive {self.substitution_defs[directive.value][0]} not implemented."
+                    f"SubstitutionDef for custom inline directive "
+                    f"{self.substitution_defs[directive.value][0]} "
+                    "not implemented."
                 )
         else:
-            return [MText(directive.value)]
+            return [directive]
 
     def _resolve(self, loc, text):
         """

--- a/papyri/tree.py
+++ b/papyri/tree.py
@@ -8,7 +8,7 @@ import logging
 
 from collections import Counter, defaultdict
 from functools import lru_cache
-from typing import Any, Dict, FrozenSet, List, Set, Tuple, Callable
+from typing import Any, Dict, FrozenSet, List, Set, Tuple, Callable, Union
 
 from .take2 import (
     Directive,
@@ -533,12 +533,15 @@ class DirectiveVisiter(TreeReplacer):
 
     """
 
+    substitution_defs: Dict[str, Union[ReplaceNode, MImage]]
+
     def __init__(
         self,
         qa: str,
         known_refs: FrozenSet[RefInfo],
         local_refs,
         substitution_defs,
+        *,
         aliases,
         version,
         config=None,

--- a/papyri/ts.py
+++ b/papyri/ts.py
@@ -503,7 +503,7 @@ class TSVisitor:
     def visit_line_block(self, node):
         # TODO
         # e.g: numpy/doc/source/user/c-info.how-to-extend.rst
-        print("Skipping node", self.as_text(node))
+        log.warning("Skipping unimplemented line_block node: %s", self.as_text(node))
         return []
 
     def visit_substitution_reference(self, node):


### PR DESCRIPTION
It took me long enough because I think I was trying to do too much. This is a first pass and definitely needs improvement but it does work. I need some feedback on whether this is the right approach and whether we should look at resolving external links too?

TODO:
- [ ] Add tests for substitution definitions in ascii_expected (currently failing)
- [ ] Implement substitution definitions for all section types in gen.py (including narrative and module docstrings)
- [ ] Implement support for custom inline directives