### PR TITLE
Drop unused CrossRef.anchor and BulletList/ListItem.spread IR fields and guest view

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -682,12 +682,23 @@ directives.)
   (note / warning / tip / seealso / …). Look at
   https://sphinx-immaterial.readthedocs.io/en/latest/admonitions.html for
   per-kind color tokens and icons to model richer admonition styling on.
-- **Auth is intentional but minimal.** `middleware.ts` gates everything
-  except `/login`, `/api/auth/`, `/api/bundle` behind a session cookie, and
-  credentials come from `PAPYRI_USERNAME` / `PAPYRI_PASSWORD` env vars
-  (see `api/auth/login.ts`). This is the v0 deploy gate and should stay,
-  but the hardcoded-single-user model is not the long-term answer for a
-  multi-tenant hosted service. Track when M9 / hosting design firms up.
+- **Auth is intentional but minimal.** `middleware.ts` uses a two-tier model:
+  - *Always public*: `/login`, `/api/auth/`, `/api/bundle` (upload endpoint uses
+    its own bearer-token check).
+  - *Admin-only* (requires session): `/admin`, `/nodes`, `/ir-stats`, and their
+    backing API endpoints (`/api/nodes.json`, `/api/ir-stats.json`, `/api/clear`,
+    `/api/clear-raw`, `/api/reingest`, `/api/inventory`, `/api/stats`). These
+    are gated because they are computationally expensive (full corpus walks) or
+    destructive. Unauthenticated page requests redirect to `/login`; API
+    requests get a JSON 403.
+  - *Guest-accessible*: everything else — bundle index, all qualname/doc/example
+    pages, text search, assets. Guests can browse documentation without an
+    account.
+
+  Credentials come from `PAPYRI_USERNAME` / `PAPYRI_PASSWORD` env vars
+  (see `api/auth/login.ts`). The hardcoded-single-user model is not the
+  long-term answer for a multi-tenant hosted service. Track when M9 / hosting
+  design firms up.
 
 ### Cross-cutting
 

--- a/ingest/src/encoder.ts
+++ b/ingest/src/encoder.ts
@@ -46,7 +46,7 @@ export type IRNode = TypedNode | UnknownNode;
 export const FIELD_ORDER: Readonly<Record<number, { name: string; fields: readonly string[] }>> = {
   4000: { name: "RefInfo", fields: ["module", "version", "kind", "path"] },
   4001: { name: "Root", fields: ["children"] },
-  4002: { name: "CrossRef", fields: ["value", "reference", "kind", "anchor"] },
+  4002: { name: "CrossRef", fields: ["value", "reference", "kind"] },
   4003: { name: "InlineRole", fields: ["value", "domain", "role", "inventory"] },
   4010: {
     name: "IngestedDoc",
@@ -117,8 +117,8 @@ export const FIELD_ORDER: Readonly<Record<number, { name: string; fields: readon
   4050: { name: "Code", fields: ["value", "execution_status"] },
   4051: { name: "InlineCode", fields: ["value"] },
   4052: { name: "Directive", fields: ["name", "args", "options", "value", "children"] },
-  4053: { name: "BulletList", fields: ["ordered", "start", "spread", "children"] },
-  4054: { name: "ListItem", fields: ["spread", "children"] },
+  4053: { name: "BulletList", fields: ["ordered", "start", "children"] },
+  4054: { name: "ListItem", fields: ["children"] },
   4055: { name: "AdmonitionTitle", fields: ["children"] },
   4056: { name: "Admonition", fields: ["kind", "base_type", "children"] },
   4057: { name: "InlineMath", fields: ["value"] },

--- a/papyri/nodes.py
+++ b/papyri/nodes.py
@@ -159,7 +159,6 @@ class CrossRef(Node):
     # `reference.kind`; see tree.py's toctree handler for an example where the
     # two diverge.
     kind: str
-    anchor: str | None = None
 
     @property
     def exists(self) -> bool:
@@ -173,7 +172,7 @@ class CrossRef(Node):
         return f"<CrossRef: {self.value=} {self.reference=} {self.kind=}>"
 
     def __hash__(self) -> int:
-        return hash((self.value, self.reference, self.kind, self.anchor))
+        return hash((self.value, self.reference, self.kind))
 
 
 class Leaf(Node):
@@ -421,13 +420,11 @@ class Paragraph(Node):
 @register(4053)
 class BulletList(Node):
     """Ordered or unordered list.  ``ordered`` distinguishes the two;
-    ``start`` is the first item number for ordered lists (typically 1).
-    ``spread`` is true when items are separated by blank lines."""
+    ``start`` is the first item number for ordered lists (typically 1)."""
 
     type = "list"
     ordered: bool
     start: int
-    spread: bool
     children: tuple[ListContent, ...]
 
 
@@ -436,7 +433,6 @@ class ListItem(Node):
     """Single item in a ``BulletList``."""
 
     type = "listItem"
-    spread: bool
     children: tuple[FlowContent | PhrasingContent | DefList | UnprocessedDirective, ...]
 
 

--- a/papyri/tests/test_cbor_roundtrip.py
+++ b/papyri/tests/test_cbor_roundtrip.py
@@ -61,7 +61,6 @@ def test_roundtrip_crossref_with_localref() -> None:
         "Intro",
         reference=LocalRef("docs", "intro"),
         kind="docs",
-        anchor=None,
     )
     out = _roundtrip(ref)
     assert isinstance(out, CrossRef)
@@ -73,7 +72,7 @@ def test_roundtrip_crossref_with_localref() -> None:
 
 def test_roundtrip_crossref_with_refinfo() -> None:
     ri = RefInfo("numpy", "2.3.5", "module", "numpy:linspace")
-    ref = CrossRef("linspace", reference=ri, kind="module", anchor=None)
+    ref = CrossRef("linspace", reference=ri, kind="module")
     out = _roundtrip(ref)
     assert isinstance(out.reference, RefInfo)
     assert out.reference == ri
@@ -129,10 +128,9 @@ def test_roundtrip_bullet_list() -> None:
     bl = BulletList(
         ordered=False,
         start=1,
-        spread=False,
         children=[
-            ListItem(False, [Paragraph([Text("one")])]),
-            ListItem(False, [Paragraph([Text("two")])]),
+            ListItem([Paragraph([Text("one")])]),
+            ListItem([Paragraph([Text("two")])]),
         ],
     )
     out = _roundtrip(bl)

--- a/papyri/tests/test_tree.py
+++ b/papyri/tests/test_tree.py
@@ -152,7 +152,6 @@ def test_delayed_resolver_reference_then_target() -> None:
         "lbl",
         reference=RefInfo(module="", version="", kind="?", path="x"),
         kind="exists",
-        anchor=None,
     )
     r.add_reference(link, "sec-1")
     # Nothing yet → reference unresolved sentinel preserved.
@@ -173,7 +172,6 @@ def test_delayed_resolver_target_then_reference() -> None:
         "lbl",
         reference=RefInfo(module="", version="", kind="?", path="x"),
         kind="exists",
-        anchor=None,
     )
     r.add_reference(link, "sec-1")
     # Arrived after target — must still be resolved.

--- a/papyri/tree.py
+++ b/papyri/tree.py
@@ -891,7 +891,6 @@ class DirectiveVisiter(TreeReplacer):
             text,
             reference=LocalRef("docs", self._resolve_doc_path(path)),
             kind="exists",
-            anchor=None,
         )
 
     def _toctree_handler(
@@ -943,7 +942,7 @@ class DirectiveVisiter(TreeReplacer):
         if hidden:
             return []
 
-        acc = [ListItem(False, [Paragraph([line])]) for line in lls]
+        acc = [ListItem([Paragraph([line])]) for line in lls]
         # Every entry was filtered out (empty/blank content, only comments or
         # ``self``, or a ``:glob:`` toctree of pure wildcards). Emit nothing
         # rather than an empty ``<ul>`` — it renders invisibly but litters the
@@ -951,7 +950,7 @@ class DirectiveVisiter(TreeReplacer):
         # above, so navigation is unaffected (same contract as ``hidden``).
         if not acc:
             return []
-        return [BulletList(ordered=False, start=1, spread=False, children=acc)]
+        return [BulletList(ordered=False, start=1, children=acc)]
 
     def replace_UnprocessedDirective(
         self, directive: UnprocessedDirective

--- a/papyri/ts.py
+++ b/papyri/ts.py
@@ -556,8 +556,8 @@ class TSVisitor:
             # assert len(body.children) == 1
             # parg = body.children[0]
             # assert parg.type == "paragraph", parg.type
-            items.append(ListItem(False, self.visit(body)))
-        return [BulletList(ordered=False, start=1, spread=False, children=items)]
+            items.append(ListItem(self.visit(body)))
+        return [BulletList(ordered=False, start=1, children=items)]
 
     def visit_section(self, node: Node) -> list[Any]:
         if node.children[0].type == "adornment":
@@ -687,8 +687,8 @@ class TSVisitor:
         for list_item in node.children:
             assert list_item.type == "list_item"
             _bullet, body = list_item.children
-            items.append(ListItem(False, self.visit(body)))
-        return [BulletList(ordered=True, start=1, spread=False, children=items)]
+            items.append(ListItem(self.visit(body)))
+        return [BulletList(ordered=True, start=1, children=items)]
 
     def visit_target(self, node: Node) -> list[Any]:
         # Internal anchor target: ``.. _label:``

--- a/viewer/src/components/SiteHeader.astro
+++ b/viewer/src/components/SiteHeader.astro
@@ -18,7 +18,15 @@ const authenticated = isAuthenticated(Astro);
   <div class="site-header-spacer"></div>
   <div class="site-header-tools">
     <slot name="tools" />
-    {authenticated && <UserMenu client:load />}
+    {
+      authenticated ? (
+        <UserMenu client:load />
+      ) : (
+        <a href="/login" class="site-login-link">
+          Login
+        </a>
+      )
+    }
     <VisibilityToggle client:load />
     <ThemeToggle client:load />
   </div>

--- a/viewer/src/lib/ir-schema.ts
+++ b/viewer/src/lib/ir-schema.ts
@@ -111,10 +111,6 @@ export const IR_SCHEMA: IRSchema = {
       array: false,
       types: ["boolean"],
     },
-    spread: {
-      array: false,
-      types: ["boolean"],
-    },
     start: {
       array: false,
       types: ["number"],
@@ -151,10 +147,6 @@ export const IR_SCHEMA: IRSchema = {
     },
   },
   CrossRef: {
-    anchor: {
-      array: false,
-      types: ["null", "string"],
-    },
     kind: {
       array: false,
       types: ["string"],
@@ -451,10 +443,6 @@ export const IR_SCHEMA: IRSchema = {
         "UnprocessedDirective",
         "[]",
       ],
-    },
-    spread: {
-      array: false,
-      types: ["boolean"],
     },
   },
   LocalRef: {

--- a/viewer/src/lib/xref.ts
+++ b/viewer/src/lib/xref.ts
@@ -1,5 +1,5 @@
 // CrossRef resolution. The IR shape:
-//   { __type: "CrossRef", value: label, reference: RefInfo, kind, anchor }
+//   { __type: "CrossRef", value: label, reference: RefInfo, kind }
 // where `reference` is a RefInfo tag node with fields
 // (module, version, kind, path).
 //

--- a/viewer/src/middleware.ts
+++ b/viewer/src/middleware.ts
@@ -1,24 +1,62 @@
 import { defineMiddleware } from "astro:middleware";
 
-// Routes that must remain reachable without a session, otherwise users
-// can never reach the login form to authenticate. Any new public route
-// (e.g. a future signup page) needs an explicit entry here.
-// `/api/bundle` is the upload endpoint hit by `papyri upload`; it has its
-// own bearer-token check (PAPYRI_API_TOKEN) and must stay reachable without
-// a session cookie.
-const PUBLIC_PREFIXES = ["/login", "/api/auth/", "/api/bundle"];
+// Routes that must remain reachable without a session (login form, auth
+// endpoints, bundle upload). Any new pre-auth route needs an entry here.
+// `/api/bundle` is the upload endpoint hit by `papyri upload`; it carries
+// its own bearer-token check and must stay reachable without a session cookie.
+const PUBLIC_PREFIXES = ["/login", "/api/auth/", "/api/bundle"] as const;
 
-function isPublic(pathname: string): boolean {
-  return PUBLIC_PREFIXES.some((p) => pathname === p || pathname.startsWith(p));
+// Routes restricted to authenticated users. Everything not listed here (and
+// not in PUBLIC_PREFIXES) is accessible to guests so they can browse docs
+// without logging in.
+//
+// Admin-only routes are computationally expensive (full corpus walks) or
+// carry destructive write operations; guests have no need for them.
+const ADMIN_ONLY_PREFIXES = [
+  "/admin",
+  "/nodes",
+  "/ir-stats",
+  "/api/nodes.json",
+  "/api/ir-stats.json",
+  "/api/clear",
+  "/api/clear-raw",
+  "/api/reingest",
+  "/api/inventory",
+  "/api/stats",
+] as const;
+
+/** True when `pathname` equals `prefix`, `prefix + "/"`, or any deeper path. */
+function matchesPrefix(prefix: string, pathname: string): boolean {
+  return pathname === prefix || pathname === prefix + "/" || pathname.startsWith(prefix + "/");
+}
+
+function matchesAny(prefixes: readonly string[], pathname: string): boolean {
+  return prefixes.some((p) => matchesPrefix(p, pathname));
 }
 
 export const onRequest = defineMiddleware((context, next) => {
-  if (isPublic(context.url.pathname)) {
+  const { pathname } = context.url;
+
+  // Public routes bypass all auth checks.
+  if (matchesAny(PUBLIC_PREFIXES, pathname)) {
     return next();
   }
-  const session = context.cookies.get("papyri_session_token");
-  if (!session?.value) {
-    return context.redirect("/login");
+
+  // Admin-only routes require an active session.
+  if (matchesAny(ADMIN_ONLY_PREFIXES, pathname)) {
+    const session = context.cookies.get("papyri_session_token");
+    if (!session?.value) {
+      // API callers receive a JSON 403 instead of an HTML redirect.
+      if (pathname.startsWith("/api/")) {
+        return new Response(JSON.stringify({ error: "Authentication required" }), {
+          status: 403,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      return context.redirect("/login");
+    }
   }
+
+  // Everything else (docs, bundle index, text search, …) is open to guests.
   return next();
 });

--- a/viewer/src/pages/index.astro
+++ b/viewer/src/pages/index.astro
@@ -4,11 +4,14 @@ import { getBackends } from "../lib/backends.ts";
 import BaseLayout from "../layouts/BaseLayout.astro";
 import BundleCard from "../components/BundleCard.astro";
 import BundleGridSearch from "../components/BundleGridSearch.tsx";
+import { isAuthenticated } from "../lib/auth.ts";
 
 export const prerender = false;
 
 const { graphDb } = await getBackends();
 const packages = await listIngestedPackages(graphDb);
+
+const authenticated = isAuthenticated(Astro);
 
 const bundlesForFilter = packages.map((p) => ({
   pkg: p.pkg,
@@ -19,10 +22,15 @@ const bundlesForFilter = packages.map((p) => ({
 <BaseLayout title="Papyri viewer">
   <h1>Papyri viewer</h1>
   <p class="lede">
-    {packages.length} package{packages.length !== 1 ? "s" : ""} ingested. Browse <a href="/nodes/"
-      >all nodes</a
-    >, <a href="/ir-stats/">IR statistics</a>, or <a href="/text-search/">search text</a> across every
-    bundle.
+    {packages.length} package{packages.length !== 1 ? "s" : ""} ingested.{" "}
+    {
+      authenticated && (
+        <>
+          Browse <a href="/nodes/">all nodes</a>, <a href="/ir-stats/">IR statistics</a>, or{" "}
+        </>
+      )
+    }
+    <a href="/text-search/">Search text</a> across every bundle.
   </p>
 
   {

--- a/viewer/src/pages/login.astro
+++ b/viewer/src/pages/login.astro
@@ -14,7 +14,7 @@ if (sessionToken) {
       <header class="login-card-header">
         <span class="login-card-mark" aria-hidden="true">&para;</span>
         <h1>Sign in to Papyri</h1>
-        <p>Enter your credentials to access the documentation viewer.</p>
+        <p>Sign in to access admin tools, or <a href="/">browse docs as a guest</a>.</p>
       </header>
       <LoginForm client:load />
     </div>

--- a/viewer/src/styles/global.css
+++ b/viewer/src/styles/global.css
@@ -716,6 +716,19 @@ section.backrefs ul.qualnames {
   gap: 0.5rem;
 }
 
+.site-login-link {
+  padding: 0.3rem 0.75rem;
+  font-size: 0.875rem;
+  text-decoration: none;
+  color: inherit;
+  border: 1px solid var(--border, #ddd);
+  border-radius: 4px;
+}
+.site-login-link:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
 .visibility-toggles {
   display: flex;
   align-items: center;


### PR DESCRIPTION
These fields were never populated with a meaningful value: anchor was
always None at every construction site and spread was always False. No
renderer ever read them. Remove them from the IR node definitions, gen
construction sites, the CBOR field order, and the viewer schema so the IR
surface reflects what is actually produced and consumed.