### PR TITLE
Add PAPYRI_SITE build arg and expose port in Docker deployment

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,8 +3,17 @@ services:
     build:
       context: .
       dockerfile: viewer/Dockerfile
+      args:
+        PAPYRI_SITE: ${PAPYRI_SITE:-}
+    ports:
+      - "${PAPYRI_PORT:-4321}:4321"
     environment:
       - PAPYRI_UPLOAD_TOKEN=${PAPYRI_UPLOAD_TOKEN:-dev}
+      # Set PAPYRI_SITE to the external URL when deploying behind a reverse
+      # proxy (e.g. PAPYRI_SITE=https://docs.example.com). Astro uses this
+      # for CSRF origin checks and canonical URL generation. Leave unset for
+      # direct access on localhost.
+      - PAPYRI_SITE=${PAPYRI_SITE:-}
     volumes:
       - papyri-data:/data
     restart: unless-stopped

--- a/viewer/Dockerfile
+++ b/viewer/Dockerfile
@@ -14,6 +14,12 @@ RUN pnpm --filter papyri-ingest build
 RUN pnpm install --frozen-lockfile
 
 COPY viewer/ ./viewer/
+
+# PAPYRI_SITE is the canonical external URL (e.g. https://docs.example.com).
+# It must be supplied at build time because Astro bakes `site` into the
+# bundle for CSRF origin checks. Leave empty for localhost/direct access.
+ARG PAPYRI_SITE=""
+ENV PAPYRI_SITE=${PAPYRI_SITE}
 RUN pnpm --filter papyri-viewer build
 
 ENV HOST=0.0.0.0

--- a/viewer/astro.config.mjs
+++ b/viewer/astro.config.mjs
@@ -19,6 +19,12 @@ import cloudflare from "@astrojs/cloudflare";
 // the adapter's worker bundle. See `viewer/PLAN.md` § M9.1.
 const ADAPTER = process.env.PAPYRI_ADAPTER ?? "node";
 
+// PAPYRI_SITE sets the canonical origin (e.g. "https://docs.example.com").
+// Astro uses this for CSRF origin checks (security.checkOrigin) and canonical
+// URL generation. Required when deployed behind a reverse proxy whose external
+// hostname differs from the container's internal host.
+const PAPYRI_SITE = process.env.PAPYRI_SITE;
+
 const adapter =
   ADAPTER === "cloudflare"
     ? cloudflare({
@@ -58,4 +64,5 @@ export default defineConfig({
   integrations: [react()],
   server: { port: 4321 },
   vite: viteCfg,
+  ...(PAPYRI_SITE ? { site: PAPYRI_SITE } : {}),
 });


### PR DESCRIPTION
Astro's CSRF origin check (security.checkOrigin) compares the request Origin against the compiled-in `site` value. Without `site` set, it falls back to the request host — fine for direct access but wrong when the container sits behind a reverse proxy with a different external hostname (e.g. https://docs.example.com vs http://0.0.0.0:4321).

- astro.config.mjs: read PAPYRI_SITE env var and pass it as `site` when present; no-op when unset so localhost dev is unchanged.
- Dockerfile: accept PAPYRI_SITE as a build ARG (must be baked in at build time since Astro embeds `site` during the build step) and expose it as an ENV so the value is visible in the image metadata.
- docker-compose.yaml: wire PAPYRI_SITE through as a build arg and runtime env var; add ports mapping (defaulting to 4321:4321 via PAPYRI_PORT) so the service is reachable without a separate proxy.