### PR TITLE
Add deployment info debug section to admin panel

### DIFF
--- a/viewer/astro.config.mjs
+++ b/viewer/astro.config.mjs
@@ -1,3 +1,4 @@
+import { execSync } from "node:child_process";
 import { defineConfig } from "astro/config";
 import react from "@astrojs/react";
 import node from "@astrojs/node";
@@ -18,6 +19,18 @@ import cloudflare from "@astrojs/cloudflare";
 // SSG contract, and only routes marked `prerender = false` end up in
 // the adapter's worker bundle. See `viewer/PLAN.md` § M9.1.
 const ADAPTER = process.env.PAPYRI_ADAPTER ?? "node";
+
+// Bake the git commit hash at build time so the admin panel can display it.
+// Falls back to PAPYRI_COMMIT env var (useful when git is unavailable in CI),
+// then to "unknown".
+let PAPYRI_BUILD_COMMIT = process.env.PAPYRI_COMMIT ?? "unknown";
+try {
+  PAPYRI_BUILD_COMMIT = execSync("git rev-parse HEAD", { stdio: ["pipe", "pipe", "ignore"] })
+    .toString()
+    .trim();
+} catch {
+  // git not available (e.g. Docker build without .git); keep env var fallback
+}
 
 // PAPYRI_SITE sets the canonical origin (e.g. "https://docs.example.com").
 // Astro uses this for CSRF origin checks (security.checkOrigin) and canonical
@@ -53,10 +66,21 @@ const adapter =
 // Workers runtime; under the Node adapter it must be marked external so
 // rollup leaves the (dynamic, runtime-guarded) import alone instead of
 // trying to bundle it. The Cloudflare adapter knows about it natively.
+// Build-time constants injected into import.meta.env for both adapters.
+// These are statically replaced by Vite at bundle time, so they work inside
+// the Cloudflare Workers bundle where process.env is unavailable at runtime.
+const buildDefine = {
+  "import.meta.env.PAPYRI_BUILD_COMMIT": JSON.stringify(PAPYRI_BUILD_COMMIT),
+  "import.meta.env.PAPYRI_BUILD_ADAPTER": JSON.stringify(ADAPTER),
+};
+
 const viteCfg =
   ADAPTER === "cloudflare"
-    ? {}
-    : { build: { rollupOptions: { external: ["cloudflare:workers"] } } };
+    ? { define: buildDefine }
+    : {
+        build: { rollupOptions: { external: ["cloudflare:workers"] } },
+        define: buildDefine,
+      };
 
 export default defineConfig({
   output: "server",

--- a/viewer/src/env.d.ts
+++ b/viewer/src/env.d.ts
@@ -1,1 +1,12 @@
 /// <reference types="astro/client" />
+
+interface ImportMetaEnv {
+  /** Git commit SHA baked in at build time (see astro.config.mjs). */
+  readonly PAPYRI_BUILD_COMMIT: string;
+  /** Adapter used at build time: "node" or "cloudflare". */
+  readonly PAPYRI_BUILD_ADAPTER: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/viewer/src/pages/admin/index.astro
+++ b/viewer/src/pages/admin/index.astro
@@ -89,6 +89,32 @@ if (probePath) {
     <h1>Admin</h1>
 
     <section class="admin-section">
+      <h2>Deployment <span class="admin-debug-tag">debug</span></h2>
+      <table class="admin-stats-table admin-deploy-table">
+        <tbody>
+          <tr>
+            <td>PAPYRI_SITE</td>
+            <td><code>{Astro.site?.href ?? <em class="admin-unset">(not set)</em>}</code></td>
+          </tr>
+          <tr>
+            <td>Request origin</td>
+            <td><code>{Astro.url.origin}</code></td>
+          </tr>
+          <tr>
+            <td>Adapter</td>
+            <td><code>{import.meta.env.PAPYRI_BUILD_ADAPTER}</code></td>
+          </tr>
+          <tr>
+            <td>Build commit</td>
+            <td>
+              <code class="admin-commit">{import.meta.env.PAPYRI_BUILD_COMMIT}</code>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section class="admin-section">
       <h2>Raw archive</h2>
       {
         rawEntries.length === 0 ? (
@@ -310,6 +336,26 @@ if (probePath) {
   }
 
   .admin-empty {
+    color: var(--color-muted, #888);
+  }
+
+  .admin-deploy-table td:first-child {
+    color: var(--color-muted, #666);
+    font-size: 0.82rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    white-space: nowrap;
+    width: 1%;
+  }
+
+  .admin-commit {
+    font-size: 0.8rem;
+    word-break: break-all;
+  }
+
+  .admin-unset {
+    font-style: italic;
     color: var(--color-muted, #888);
   }
 


### PR DESCRIPTION
Adds a new "Deployment" debug section to the admin panel that displays build-time and runtime configuration information, helping with debugging deployment issues.

## Changes

- **Admin panel UI**: Added a new "Deployment" section displaying:
  - `PAPYRI_SITE` — the canonical site origin (from `Astro.site`)
  - Request origin — the current request's origin
  - Adapter — which adapter was used at build time ("node" or "cloudflare")
  - Build commit — the git commit SHA baked in at build time

- **Build-time constants**: Modified `astro.config.mjs` to:
  - Capture the git commit hash via `git rev-parse HEAD` at build time
  - Fall back to `PAPYRI_COMMIT` environment variable (for CI environments without `.git`)
  - Fall back to "unknown" if neither is available
  - Inject both `PAPYRI_BUILD_COMMIT` and `PAPYRI_BUILD_ADAPTER` into `import.meta.env` via Vite's `define` option (works in both Node and Cloudflare Workers adapters)

- **TypeScript types**: Added `ImportMetaEnv` interface in `env.d.ts` to type the new build-time constants

- **Styling**: Added CSS for the deployment table and related elements (muted labels, monospace commit hash with word-breaking, italicized "(not set)" indicator)

## Implementation details

The build-time constants are injected via Vite's `define` option rather than `process.env` because Cloudflare Workers bundles don't have access to `process.env` at runtime. Static string replacement ensures the values are available in both deployment targets.

https://claude.ai/code/session_015U721nwm7oCgETQ2MFb8Fw