### PR TITLE
Misc Updates (viewer search, upload config, disable origin check)

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -643,8 +643,117 @@ Environment variables read by ``--upload``:
      - Description
    * - ``PAPYRI_UPLOAD_URL``
      - Viewer ingest endpoint (default: ``http://localhost:4321/api/bundle``).
+       Overridden by a named target if ``default_target`` is set in
+       ``~/.papyri/config.toml``.
    * - ``PAPYRI_UPLOAD_TOKEN``
-     - Bearer token for the ingest endpoint.
+     - Bearer token for the ingest endpoint.  Overridden by a named target's
+       token or keychain entry if ``default_target`` is set.
+
+
+.. _upload-config:
+
+``~/.papyri/config.toml`` — user upload config
+------------------------------------------------
+
+``papyri upload`` reads an optional user-level config file at
+``~/.papyri/config.toml``.  It lets you define **named upload targets**
+so you can type ``papyri upload --to staging`` instead of repeating a
+long URL and token on every invocation.
+
+The file is separate from the per-library TOML config used by
+``papyri gen``.
+
+.. code:: toml
+
+   # ~/.papyri/config.toml
+
+   [upload]
+   # Optional: use this target when --to is not given.
+   default_target = "localhost"
+
+   # ── targets ────────────────────────────────────────────────────────────
+
+   [upload.targets.localhost]
+   url = "http://localhost:4321/api/bundle"
+   # No token needed for a local dev instance.
+
+   [upload.targets.staging]
+   url   = "https://staging.example.com/api/bundle"
+   token = "my-staging-token"        # plain-text — OK for dev/staging
+
+   [upload.targets.production]
+   url      = "https://docs.example.com/api/bundle"
+   keychain = true                   # read token from system keychain
+
+
+``[upload.targets.<name>]`` keys
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 15 65
+
+   * - Key
+     - Required
+     - Description
+   * - ``url``
+     - **yes**
+     - Full URL of the viewer's ``/api/bundle`` ingest endpoint.
+   * - ``token``
+     - no
+     - Bearer token as plain text.  Cannot be combined with ``keychain``.
+   * - ``keychain``
+     - no
+     - When ``true``, the token is fetched from the system keychain at
+       upload time.  See :ref:`upload-keychain`.  Cannot be combined with ``token``.
+
+``[upload]`` keys
+~~~~~~~~~~~~~~~~~
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 75
+
+   * - Key
+     - Description
+   * - ``default_target``
+     - Name of the target to use when ``--to`` is not supplied.  Must
+       match a key under ``[upload.targets]``.  Omit to keep the current
+       behaviour (fall through to ``$PAPYRI_UPLOAD_URL`` / hardcoded
+       default).
+
+
+.. _upload-keychain:
+
+Storing tokens in the system keychain
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Setting ``keychain = true`` in a target tells ``papyri upload`` to look
+up the bearer token from the OS credential store at upload time, rather
+than storing it in the config file.  The lookup uses the `keyring
+<https://pypi.org/project/keyring/>`__ package (macOS Keychain, Windows
+Credential Manager, Linux Secret Service / KWallet).
+
+**Install keyring support:**
+
+.. code:: bash
+
+   pip install "papyri[keychain]"
+
+**Store a token (run once per machine / token rotation):**
+
+.. code:: bash
+
+   python -m keyring set papyri <target-name>
+   # e.g.
+   python -m keyring set papyri production
+
+You will be prompted for the token value.  It is then encrypted and
+stored in the OS credential store; ``papyri upload`` retrieves it
+automatically.  The token never appears in ``~/.papyri/config.toml``.
+
+If ``keyring`` is not installed or no entry is found, the upload fails
+with a clear message explaining the fix.
 
 
 ``papyri upload`` CLI reference
@@ -660,20 +769,57 @@ directory (packed on the fly).
 
 .. list-table::
    :header-rows: 1
-   :widths: 25 20 55
+   :widths: 20 20 60
 
    * - Option
      - Default
      - Description
-   * - ``--url`` / ``-u``
-     - ``http://localhost:4321/api/bundle``
-     - Viewer ingest endpoint.  Overridden by ``$PAPYRI_UPLOAD_URL``.
-   * - ``--token`` / ``-t``
+   * - ``--to NAME``
      - —
-     - Bearer token for ``/api/bundle``.  Overridden by ``$PAPYRI_UPLOAD_TOKEN``.  Omit for local dev instances with no auth.
+     - Named target from ``~/.papyri/config.toml``.  Supplies the URL and
+       token for that target.  Explicit ``--url`` / ``--token`` flags
+       override ``--to``.
+   * - ``--url`` / ``-u``
+     - see below
+     - Viewer ingest endpoint.  Overrides ``--to`` and
+       ``$PAPYRI_UPLOAD_URL``.
+   * - ``--token`` / ``-t``
+     - see below
+     - Bearer token.  Overrides ``--to`` and ``$PAPYRI_UPLOAD_TOKEN``.
+       Omit for local dev instances with no auth.
    * - ``--verbose`` / ``-v``
      - ``false``
      - Show per-step packing progress when building a bundle on the fly.
+
+**URL resolution order** (first match wins):
+
+1. ``--url`` flag
+2. ``--to`` target's ``url`` (or ``default_target`` from config if ``--to`` is omitted)
+3. ``$PAPYRI_UPLOAD_URL`` environment variable
+4. ``http://localhost:4321/api/bundle``
+
+**Token resolution order** (first match wins):
+
+1. ``--token`` flag
+2. ``--to`` target's ``token`` / ``keychain`` entry
+3. ``$PAPYRI_UPLOAD_TOKEN`` environment variable
+4. *(no token — omit the ``Authorization`` header)*
+
+**Typical workflows:**
+
+.. code:: bash
+
+   # Local dev (no config needed — hits localhost by default).
+   papyri upload ~/.papyri/data/mylib_1.0/
+
+   # Named target from config (URL + token resolved automatically).
+   papyri upload --to staging mylib-1.0.papyri
+
+   # Named target but override URL for a one-off.
+   papyri upload --to production --url https://override.example.com/api/bundle mylib.papyri
+
+   # One-off with explicit credentials (no config file needed).
+   papyri upload --url https://docs.example.com/api/bundle --token $MY_TOKEN mylib.papyri
 
 
 ``papyri pack`` CLI reference

--- a/papyri/cli/upload.py
+++ b/papyri/cli/upload.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -49,6 +50,43 @@ def _load_from_zip(path: Path) -> tuple[bytes, Bundle]:
     return data, bundle
 
 
+def _resolve_upload_params(
+    url_flag: str | None,
+    token_flag: str | None,
+    to: str | None,
+) -> tuple[str, str | None]:
+    """Return (effective_url, effective_token) applying the full resolution chain.
+
+    Priority (highest to lowest):
+    1. Explicit ``--url`` / ``--token`` CLI flags.
+    2. Named target from ``--to`` (URL and token/keychain from config).
+    3. ``$PAPYRI_UPLOAD_URL`` / ``$PAPYRI_UPLOAD_TOKEN`` env vars.
+    4. Hardcoded default URL (``http://localhost:4321/api/bundle``).
+    """
+    from papyri.user_config import get_target, load_user_config
+
+    user_cfg = load_user_config()
+
+    # Determine which named target to use (--to takes precedence over default_target).
+    effective_to = to if to is not None else user_cfg.default_target
+
+    target_url: str | None = None
+    target_token: str | None = None
+    if effective_to is not None:
+        target = get_target(user_cfg, effective_to)
+        target_url = target.url
+        target_token = target.resolve_token(effective_to)
+
+    effective_url = (
+        url_flag or target_url or os.environ.get("PAPYRI_UPLOAD_URL") or _DEFAULT_URL
+    )
+    effective_token = (
+        token_flag or target_token or os.environ.get("PAPYRI_UPLOAD_TOKEN")
+    )
+
+    return effective_url, effective_token
+
+
 def upload(
     paths: Annotated[
         list[Path],
@@ -61,24 +99,40 @@ def upload(
             ),
         ),
     ],
+    to: Annotated[
+        str | None,
+        typer.Option(
+            "--to",
+            help=(
+                "Named upload target defined in ~/.papyri/config.toml "
+                "(e.g. 'staging', 'production').  "
+                "Overrides $PAPYRI_UPLOAD_URL / $PAPYRI_UPLOAD_TOKEN.  "
+                "Explicit --url / --token flags override --to."
+            ),
+        ),
+    ] = None,
     url: Annotated[
-        str,
+        str | None,
         typer.Option(
             "--url",
             "-u",
-            envvar="PAPYRI_UPLOAD_URL",
-            help="URL of the viewer ingest endpoint.  Overridden by $PAPYRI_UPLOAD_URL.",
+            help=(
+                "URL of the viewer ingest endpoint.  "
+                "Overrides --to and $PAPYRI_UPLOAD_URL.  "
+                "Defaults to $PAPYRI_UPLOAD_URL, then the target set by --to, "
+                "then http://localhost:4321/api/bundle."
+            ),
         ),
-    ] = _DEFAULT_URL,
+    ] = None,
     token: Annotated[
         str | None,
         typer.Option(
             "--token",
             "-t",
-            envvar="PAPYRI_UPLOAD_TOKEN",
             help=(
                 "Bearer token for /api/bundle authentication.  "
-                "Overridden by $PAPYRI_UPLOAD_TOKEN.  "
+                "Overrides --to and $PAPYRI_UPLOAD_TOKEN.  "
+                "Defaults to $PAPYRI_UPLOAD_TOKEN, then the target set by --to.  "
                 "Omit when the viewer has no token configured (local dev)."
             ),
         ),
@@ -110,13 +164,38 @@ def upload(
     server-side; this is the canonical way to ship a bundle into the
     cross-linked graph.
 
-    Authentication: if the viewer has ``PAPYRI_UPLOAD_TOKEN`` configured,
-    set the same value here (via ``--token`` or ``$PAPYRI_UPLOAD_TOKEN``)
-    so the request is accepted.
+    **Named targets** (recommended for repeated use)::
+
+        # ~/.papyri/config.toml
+        [upload.targets.staging]
+        url = "https://staging.example.com/api/bundle"
+        token = "my-token"
+
+        [upload.targets.production]
+        url = "https://docs.example.com/api/bundle"
+        keychain = true   # token stored in system keychain
+
+    Then: ``papyri upload --to staging mybundle.papyri``
+
+    For keychain targets, store the token once with::
+
+        python -m keyring set papyri production
+
+    **Token resolution order**: ``--token`` flag > ``--to`` target
+    (config file or keychain) > ``$PAPYRI_UPLOAD_TOKEN`` env var.
+
+    **URL resolution order**: ``--url`` flag > ``--to`` target > ``$PAPYRI_UPLOAD_URL``
+    env var > ``http://localhost:4321/api/bundle``.
     """
     import time
 
     from papyri.pack import BundleError, load_artifact, make_artifact_from_dir
+
+    try:
+        effective_url, effective_token = _resolve_upload_params(url, token, to)
+    except (KeyError, ValueError, RuntimeError) as exc:
+        typer.echo(f"error: {exc}", err=True)
+        raise typer.Exit(1) from exc
 
     ok = True
     total = len(paths)
@@ -162,7 +241,7 @@ def upload(
 
         size_mb = len(data) / (1024 * 1024)
         typer.echo(
-            f"{prefix} uploading {pkg} {version} ({size_mb:.2f} MiB) → {url}",
+            f"{prefix} uploading {pkg} {version} ({size_mb:.2f} MiB) → {effective_url}",
             err=True,
         )
 
@@ -174,15 +253,17 @@ def upload(
         # request host with "Cross-site PUT form submissions are forbidden".
         # `/api/bundle` is meant for cross-origin CLI use, so we set Origin
         # to the upload URL's own scheme+host to satisfy the check.
-        parsed = urllib.parse.urlsplit(url)
+        parsed = urllib.parse.urlsplit(effective_url)
         headers: dict[str, str] = {
             "Content-Type": "application/gzip",
             "User-Agent": f"papyri-upload/{_PAPYRI_VERSION}",
             "Origin": f"{parsed.scheme}://{parsed.netloc}",
         }
-        if token:
-            headers["Authorization"] = f"Bearer {token}"
-        req = urllib.request.Request(url, data=data, method="PUT", headers=headers)
+        if effective_token:
+            headers["Authorization"] = f"Bearer {effective_token}"
+        req = urllib.request.Request(
+            effective_url, data=data, method="PUT", headers=headers
+        )
         t0 = time.monotonic()
         try:
             with urllib.request.urlopen(req) as resp:

--- a/papyri/config.py
+++ b/papyri/config.py
@@ -13,6 +13,7 @@ base_dir = Path(expanduser("~/.papyri/"))
 
 ingest_dir = base_dir / "ingest"
 data_dir = base_dir / "data"
+user_config_path = base_dir / "config.toml"
 
 
 def ensure_dirs() -> None:

--- a/papyri/tests/test_cli_upload.py
+++ b/papyri/tests/test_cli_upload.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import gzip
 import io
 import json
+import textwrap
 import urllib.error
 import urllib.request
 from pathlib import Path
@@ -392,3 +393,135 @@ def test_upload_zip_multiple_papyri_files(tmp_path: Any) -> None:
     result = runner.invoke(_app, [str(zip_path)])
     assert result.exit_code == 1
     assert "2 .papyri files" in result.output
+
+
+# ---------------------------------------------------------------------------
+# --to named target
+# ---------------------------------------------------------------------------
+
+
+def _write_config(path: Path, content: str) -> None:
+    path.write_text(textwrap.dedent(content))
+
+
+def test_upload_to_named_target_uses_target_url(tmp_path: Path) -> None:
+    cfg = tmp_path / "config.toml"
+    _write_config(
+        cfg,
+        """\
+        [upload.targets.staging]
+        url = "https://staging.example.com/api/bundle"
+        token = "stagetoken"
+        """,
+    )
+    bundle = _make_bundle(tmp_path / "mypkg_1.0")
+    resp = _mock_response({"ok": True, "pkg": "mypkg", "version": "1.0"})
+
+    with (
+        patch("urllib.request.urlopen", return_value=resp) as mock_open,
+        patch("papyri.user_config.USER_CONFIG_PATH", cfg),
+    ):
+        result = runner.invoke(_app, [str(bundle), "--to", "staging"])
+
+    assert result.exit_code == 0, result.output
+    req: urllib.request.Request = mock_open.call_args[0][0]
+    assert req.full_url == "https://staging.example.com/api/bundle"
+    assert req.get_header("Authorization") == "Bearer stagetoken"
+
+
+def test_upload_explicit_url_overrides_to(tmp_path: Path) -> None:
+    cfg = tmp_path / "config.toml"
+    _write_config(
+        cfg,
+        """\
+        [upload.targets.staging]
+        url = "https://staging.example.com/api/bundle"
+        """,
+    )
+    bundle = _make_bundle(tmp_path / "mypkg_1.0")
+    resp = _mock_response({"ok": True, "pkg": "mypkg", "version": "1.0"})
+
+    with (
+        patch("urllib.request.urlopen", return_value=resp) as mock_open,
+        patch("papyri.user_config.USER_CONFIG_PATH", cfg),
+    ):
+        result = runner.invoke(
+            _app,
+            [
+                str(bundle),
+                "--to",
+                "staging",
+                "--url",
+                "http://override.example.com/api/bundle",
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    req: urllib.request.Request = mock_open.call_args[0][0]
+    assert req.full_url == "http://override.example.com/api/bundle"
+
+
+def test_upload_to_unknown_target_exits_with_error(tmp_path: Path) -> None:
+    cfg = tmp_path / "config.toml"
+    _write_config(
+        cfg,
+        """\
+        [upload.targets.localhost]
+        url = "http://localhost:4321/api/bundle"
+        """,
+    )
+    bundle = _make_bundle(tmp_path / "mypkg_1.0")
+
+    with patch("papyri.user_config.USER_CONFIG_PATH", cfg):
+        result = runner.invoke(_app, [str(bundle), "--to", "production"])
+
+    assert result.exit_code == 1
+    assert "production" in result.output
+
+
+def test_upload_default_target_used_when_no_to(tmp_path: Path) -> None:
+    cfg = tmp_path / "config.toml"
+    _write_config(
+        cfg,
+        """\
+        [upload]
+        default_target = "myserver"
+
+        [upload.targets.myserver]
+        url = "http://myserver.example.com/api/bundle"
+        """,
+    )
+    bundle = _make_bundle(tmp_path / "mypkg_1.0")
+    resp = _mock_response({"ok": True, "pkg": "mypkg", "version": "1.0"})
+
+    with (
+        patch("urllib.request.urlopen", return_value=resp) as mock_open,
+        patch("papyri.user_config.USER_CONFIG_PATH", cfg),
+    ):
+        result = runner.invoke(_app, [str(bundle)])
+
+    assert result.exit_code == 0, result.output
+    req: urllib.request.Request = mock_open.call_args[0][0]
+    assert req.full_url == "http://myserver.example.com/api/bundle"
+
+
+def test_upload_env_var_used_when_no_to_and_no_config(tmp_path: Path) -> None:
+    cfg = tmp_path / "nonexistent_config.toml"  # file does not exist
+    bundle = _make_bundle(tmp_path / "mypkg_1.0")
+    resp = _mock_response({"ok": True, "pkg": "mypkg", "version": "1.0"})
+
+    env_url = "http://envvar.example.com/api/bundle"
+
+    with (
+        patch("urllib.request.urlopen", return_value=resp) as mock_open,
+        patch("papyri.user_config.USER_CONFIG_PATH", cfg),
+        patch(
+            "papyri.cli.upload.os.environ.get",
+            side_effect=lambda k, d=None: env_url if k == "PAPYRI_UPLOAD_URL" else d,
+        ),
+    ):
+        result = runner.invoke(_app, [str(bundle)])
+
+    assert result.exit_code == 0, result.output
+    req: urllib.request.Request = mock_open.call_args[0][0]
+    assert req.full_url == env_url

--- a/papyri/tests/test_user_config.py
+++ b/papyri/tests/test_user_config.py
@@ -1,0 +1,225 @@
+"""Tests for papyri.user_config — named upload target config."""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from papyri.user_config import (
+    UploadTarget,
+    UserConfig,
+    get_target,
+    list_targets,
+    load_user_config,
+)
+
+# ---------------------------------------------------------------------------
+# load_user_config
+# ---------------------------------------------------------------------------
+
+
+def test_load_absent_file(tmp_path: Path) -> None:
+    cfg = load_user_config(tmp_path / "config.toml")
+    assert cfg.default_target is None
+    assert cfg.targets == {}
+
+
+def test_load_minimal_target(tmp_path: Path) -> None:
+    p = tmp_path / "config.toml"
+    p.write_text(
+        textwrap.dedent("""\
+        [upload.targets.localhost]
+        url = "http://localhost:4321/api/bundle"
+        """)
+    )
+    cfg = load_user_config(p)
+    assert "localhost" in cfg.targets
+    assert cfg.targets["localhost"].url == "http://localhost:4321/api/bundle"
+    assert cfg.targets["localhost"].token is None
+    assert cfg.targets["localhost"].keychain is False
+
+
+def test_load_target_with_token(tmp_path: Path) -> None:
+    p = tmp_path / "config.toml"
+    p.write_text(
+        textwrap.dedent("""\
+        [upload.targets.staging]
+        url = "https://staging.example.com/api/bundle"
+        token = "mytoken"
+        """)
+    )
+    cfg = load_user_config(p)
+    assert cfg.targets["staging"].token == "mytoken"
+    assert cfg.targets["staging"].keychain is False
+
+
+def test_load_target_with_keychain(tmp_path: Path) -> None:
+    p = tmp_path / "config.toml"
+    p.write_text(
+        textwrap.dedent("""\
+        [upload.targets.production]
+        url = "https://docs.example.com/api/bundle"
+        keychain = true
+        """)
+    )
+    cfg = load_user_config(p)
+    assert cfg.targets["production"].keychain is True
+    assert cfg.targets["production"].token is None
+
+
+def test_load_default_target(tmp_path: Path) -> None:
+    p = tmp_path / "config.toml"
+    p.write_text(
+        textwrap.dedent("""\
+        [upload]
+        default_target = "localhost"
+
+        [upload.targets.localhost]
+        url = "http://localhost:4321/api/bundle"
+        """)
+    )
+    cfg = load_user_config(p)
+    assert cfg.default_target == "localhost"
+
+
+def test_load_multiple_targets(tmp_path: Path) -> None:
+    p = tmp_path / "config.toml"
+    p.write_text(
+        textwrap.dedent("""\
+        [upload.targets.a]
+        url = "http://a.example.com/"
+
+        [upload.targets.b]
+        url = "http://b.example.com/"
+        token = "tokb"
+        """)
+    )
+    cfg = load_user_config(p)
+    assert set(cfg.targets) == {"a", "b"}
+    assert cfg.targets["b"].token == "tokb"
+
+
+# ---------------------------------------------------------------------------
+# Validation errors
+# ---------------------------------------------------------------------------
+
+
+def test_missing_url_raises(tmp_path: Path) -> None:
+    p = tmp_path / "config.toml"
+    p.write_text("[upload.targets.bad]\ntoken = 'x'\n")
+    with pytest.raises(ValueError, match="missing the required 'url'"):
+        load_user_config(p)
+
+
+def test_unknown_key_raises(tmp_path: Path) -> None:
+    p = tmp_path / "config.toml"
+    p.write_text("[upload.targets.t]\nurl = 'http://x/'\nfoo = 'bar'\n")
+    with pytest.raises(ValueError, match="unknown keys"):
+        load_user_config(p)
+
+
+def test_token_and_keychain_raises(tmp_path: Path) -> None:
+    p = tmp_path / "config.toml"
+    p.write_text(
+        "[upload.targets.t]\nurl = 'http://x/'\ntoken = 'abc'\nkeychain = true\n"
+    )
+    with pytest.raises(ValueError, match="cannot set both"):
+        load_user_config(p)
+
+
+def test_default_target_not_in_targets_raises(tmp_path: Path) -> None:
+    p = tmp_path / "config.toml"
+    p.write_text(
+        textwrap.dedent("""\
+        [upload]
+        default_target = "missing"
+
+        [upload.targets.localhost]
+        url = "http://localhost/"
+        """)
+    )
+    with pytest.raises(ValueError, match=r"default_target.*missing"):
+        load_user_config(p)
+
+
+def test_invalid_toml_raises(tmp_path: Path) -> None:
+    p = tmp_path / "config.toml"
+    p.write_text("[[[ not valid toml")
+    with pytest.raises(ValueError, match="Cannot parse"):
+        load_user_config(p)
+
+
+# ---------------------------------------------------------------------------
+# UploadTarget.resolve_token
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_token_plain() -> None:
+    t = UploadTarget(url="http://x/", token="abc")
+    assert t.resolve_token("myname") == "abc"
+
+
+def test_resolve_token_none() -> None:
+    t = UploadTarget(url="http://x/")
+    assert t.resolve_token("myname") is None
+
+
+def test_resolve_token_keychain_found() -> None:
+    t = UploadTarget(url="http://x/", keychain=True)
+    fake_keyring = MagicMock()
+    fake_keyring.get_password.return_value = "secret"
+    with patch.dict("sys.modules", {"keyring": fake_keyring}):
+        assert t.resolve_token("prod") == "secret"
+    fake_keyring.get_password.assert_called_once_with("papyri", "prod")
+
+
+def test_resolve_token_keychain_missing() -> None:
+    t = UploadTarget(url="http://x/", keychain=True)
+    fake_keyring = MagicMock()
+    fake_keyring.get_password.return_value = None
+    with (
+        patch.dict("sys.modules", {"keyring": fake_keyring}),
+        pytest.raises(RuntimeError, match="No token found in keychain"),
+    ):
+        t.resolve_token("prod")
+
+
+def test_resolve_token_keychain_no_keyring() -> None:
+    t = UploadTarget(url="http://x/", keychain=True)
+    with (
+        patch.dict("sys.modules", {"keyring": None}),
+        pytest.raises((RuntimeError, ImportError)),
+    ):
+        t.resolve_token("prod")
+
+
+# ---------------------------------------------------------------------------
+# get_target / list_targets
+# ---------------------------------------------------------------------------
+
+
+def test_get_target_found() -> None:
+    cfg = UserConfig(
+        targets={"a": UploadTarget(url="http://a/"), "b": UploadTarget(url="http://b/")}
+    )
+    assert get_target(cfg, "a").url == "http://a/"
+
+
+def test_get_target_not_found() -> None:
+    cfg = UserConfig(targets={"a": UploadTarget(url="http://a/")})
+    with pytest.raises(KeyError, match="not found"):
+        get_target(cfg, "missing")
+
+
+def test_list_targets_sorted() -> None:
+    cfg = UserConfig(
+        targets={
+            "z": UploadTarget(url="http://z/"),
+            "a": UploadTarget(url="http://a/"),
+            "m": UploadTarget(url="http://m/"),
+        }
+    )
+    assert list_targets(cfg) == ["a", "m", "z"]

--- a/papyri/user_config.py
+++ b/papyri/user_config.py
@@ -1,0 +1,150 @@
+"""User-level config (~/.papyri/config.toml) for papyri CLI.
+
+Defines named upload targets so ``papyri upload --to <name>`` can resolve a
+URL and token without repeating them on every invocation.
+
+Config path: ``~/.papyri/config.toml``
+
+Example::
+
+    [upload]
+    default_target = "localhost"
+
+    [upload.targets.localhost]
+    url = "http://localhost:4321/api/bundle"
+
+    [upload.targets.staging]
+    url = "https://staging.example.com/api/bundle"
+    token = "plaintext-token"
+
+    [upload.targets.production]
+    url = "https://docs.example.com/api/bundle"
+    keychain = true  # reads from system keychain; see UploadTarget.resolve_token
+"""
+
+from __future__ import annotations
+
+import tomllib
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+# Canonical path — matches papyri/config.py's base_dir.
+USER_CONFIG_PATH = Path("~/.papyri/config.toml")
+
+
+@dataclass
+class UploadTarget:
+    """A named upload destination."""
+
+    url: str
+    token: str | None = None
+    keychain: bool = False
+
+    def resolve_token(self, name: str) -> str | None:
+        """Return the bearer token for this target.
+
+        Resolution order:
+        1. ``token`` field (plain-text in config).
+        2. System keychain (when ``keychain = true``), looked up via
+           ``keyring.get_password("papyri", name)``.
+        3. ``None`` — no token configured.
+
+        Raises ``RuntimeError`` when ``keychain = true`` but ``keyring`` is not
+        installed or has no entry for this target.
+        """
+        if self.token is not None:
+            return self.token
+        if self.keychain:
+            try:
+                import keyring
+            except ImportError as exc:
+                raise RuntimeError(
+                    f"Target '{name}' uses keychain storage but the 'keyring' "
+                    "package is not installed.  Install it with:  pip install keyring"
+                ) from exc
+            stored: str | None = keyring.get_password("papyri", name)
+            if stored is None:
+                raise RuntimeError(
+                    f"No token found in keychain for target '{name}'.  "
+                    f"Store one with:  python -m keyring set papyri {name}"
+                )
+            return stored
+        return None
+
+
+@dataclass
+class UserConfig:
+    """Parsed contents of ``~/.papyri/config.toml``."""
+
+    default_target: str | None = None
+    targets: dict[str, UploadTarget] = field(default_factory=dict)
+
+
+def load_user_config(path: Path | None = None) -> UserConfig:
+    """Load the user config file, returning an empty config if the file is absent.
+
+    ``path`` defaults to ``~/.papyri/config.toml`` and is overridable for
+    testing.
+    """
+    resolved = (path or USER_CONFIG_PATH).expanduser()
+    if not resolved.exists():
+        return UserConfig()
+
+    try:
+        raw: dict[str, Any] = tomllib.loads(resolved.read_text(encoding="utf-8"))
+    except tomllib.TOMLDecodeError as exc:
+        raise ValueError(f"Cannot parse {resolved}: {exc}") from exc
+
+    upload_section: dict[str, Any] = raw.get("upload", {})
+    default_target: str | None = upload_section.get("default_target")
+    targets_raw: dict[str, Any] = upload_section.get("targets", {})
+
+    targets: dict[str, UploadTarget] = {}
+    for tname, tdata in targets_raw.items():
+        if not isinstance(tdata, dict):
+            raise ValueError(
+                f"[upload.targets.{tname}] must be a TOML table, got {type(tdata).__name__}"
+            )
+        if "url" not in tdata:
+            raise ValueError(
+                f"[upload.targets.{tname}] is missing the required 'url' key"
+            )
+        unknown = set(tdata) - {"url", "token", "keychain"}
+        if unknown:
+            raise ValueError(
+                f"[upload.targets.{tname}] has unknown keys: {', '.join(sorted(unknown))}"
+            )
+        if tdata.get("token") is not None and tdata.get("keychain"):
+            raise ValueError(
+                f"[upload.targets.{tname}] cannot set both 'token' and 'keychain = true'"
+            )
+        targets[tname] = UploadTarget(
+            url=tdata["url"],
+            token=tdata.get("token"),
+            keychain=bool(tdata.get("keychain", False)),
+        )
+
+    if default_target is not None and default_target not in targets:
+        raise ValueError(
+            f"[upload] default_target = '{default_target}' does not match "
+            f"any defined target.  Available: {', '.join(targets) or '(none)'}"
+        )
+
+    return UserConfig(default_target=default_target, targets=targets)
+
+
+def list_targets(config: UserConfig) -> list[str]:
+    """Return target names in sorted order."""
+    return sorted(config.targets)
+
+
+def get_target(config: UserConfig, name: str) -> UploadTarget:
+    """Look up a named target, raising ``KeyError`` with a helpful message if absent."""
+    if name not in config.targets:
+        available = ", ".join(sorted(config.targets)) or "(none)"
+        raise KeyError(
+            f"Upload target '{name}' not found in {USER_CONFIG_PATH}.  "
+            f"Available targets: {available}"
+        )
+    return config.targets[name]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ readme = "Readme.md"
 license = {file = "LICENSE"}
 dynamic = ["version","description"]
 requires-python=">=3.13"
+
 dependencies = [
     "cbor2>=6.1.1",
     "ipython",
@@ -23,6 +24,9 @@ dependencies = [
     "py-tree-sitter-rst>=0.2.2",
     "typer>=0.9",
 ]
+
+[project.optional-dependencies]
+keychain = ["keyring"]
 
 [project.scripts]
 papyri = "papyri:app"

--- a/viewer/astro.config.mjs
+++ b/viewer/astro.config.mjs
@@ -58,4 +58,10 @@ export default defineConfig({
   integrations: [react()],
   server: { port: 4321 },
   vite: viteCfg,
+  // Astro v5 enables checkOrigin by default for server output, but all
+  // mutating API endpoints (/api/bundle, /api/reingest, …) carry their own
+  // bearer-token or session-cookie checks, so the Origin cross-check adds no
+  // security while breaking PUT requests forwarded by a reverse proxy (Caddy,
+  // nginx) whose external host differs from localhost:4321.
+  security: { checkOrigin: false },
 });

--- a/viewer/src/components/BundleSearch.tsx
+++ b/viewer/src/components/BundleSearch.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useState, type ReactElement } from "react";
+import { useEffect, useRef, useState, type ReactElement } from "react";
 import { linkForQualname } from "../lib/links.ts";
-import { filterQualnames, type SearchHit } from "../lib/search.ts";
+import { filterQualnames } from "../lib/search.ts";
+import { qualnameLabel, qualnameParent } from "../lib/qualname.ts";
 
 interface Props {
   pkg: string;
@@ -13,11 +14,19 @@ interface Props {
 // `src/pages/[pkg]/[ver]/search.json.ts`), then filters client-side on each
 // keystroke. The filter helper is pulled out to `lib/search.ts` so it can
 // be unit-tested without hydrating React.
+//
+// The sidebar trigger opens a native <dialog> overlay with more room for
+// results and a two-line layout (leaf name + dimmed module path).
+// Arrow keys navigate through results; Enter follows the selected link.
 export default function BundleSearch({ pkg, ver }: Props): ReactElement {
   const [qualnames, setQualnames] = useState<readonly string[]>([]);
   const [query, setQuery] = useState("");
   const [ready, setReady] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [isOpen, setIsOpen] = useState(false);
+  const [selectedIndex, setSelectedIndex] = useState(-1);
+  const dialogRef = useRef<HTMLDialogElement>(null);
+  const itemRefs = useRef<(HTMLLIElement | null)[]>([]);
 
   useEffect(() => {
     let cancelled = false;
@@ -42,35 +51,114 @@ export default function BundleSearch({ pkg, ver }: Props): ReactElement {
     };
   }, [pkg, ver]);
 
-  const hits: SearchHit[] = filterQualnames(qualnames, query, 50);
+  useEffect(() => {
+    if (isOpen) {
+      dialogRef.current?.showModal();
+    } else {
+      dialogRef.current?.close();
+      setQuery("");
+    }
+  }, [isOpen]);
+
+  // Reset keyboard selection whenever the result list changes.
+  useEffect(() => {
+    setSelectedIndex(-1);
+  }, [query]);
+
+  // Keep the selected item scrolled into view.
+  useEffect(() => {
+    if (selectedIndex >= 0) {
+      itemRefs.current[selectedIndex]?.scrollIntoView({ block: "nearest" });
+    }
+  }, [selectedIndex]);
+
+  const hits = filterQualnames(qualnames, query, 100);
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setSelectedIndex((i) => Math.min(i + 1, hits.length - 1));
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setSelectedIndex((i) => Math.max(i - 1, -1));
+    } else if (e.key === "Enter" && selectedIndex >= 0 && hits[selectedIndex]) {
+      window.location.href = linkForQualname(pkg, ver, hits[selectedIndex].qualname);
+      setIsOpen(false);
+    }
+  };
 
   return (
-    <div className="bundle-search">
-      <input
-        type="search"
-        placeholder={
-          ready ? `Search ${qualnames.length} qualnames in ${pkg}` : "Loading search index..."
-        }
-        value={query}
-        onChange={(e) => setQuery(e.target.value)}
-        aria-label="Search qualnames"
+    <>
+      <button
+        className="bundle-search-trigger"
+        onClick={() => setIsOpen(true)}
         disabled={!ready}
-        className="bundle-search-input"
-      />
+        aria-label="Search API symbols"
+        title="Search API symbols"
+      >
+        <span className="bundle-search-trigger-icon">⌕</span>
+        <span className="bundle-search-trigger-text">
+          {ready ? `Search ${qualnames.length} symbols…` : "Loading…"}
+        </span>
+      </button>
       {error ? <p className="bundle-search-error">Failed to load search index: {error}</p> : null}
-      {query.trim() !== "" ? (
-        <ul className="bundle-search-results">
-          {hits.length === 0 ? (
-            <li className="bundle-search-empty">No matches</li>
-          ) : (
-            hits.map((h) => (
-              <li key={h.qualname}>
-                <a href={linkForQualname(pkg, ver, h.qualname)}>{h.qualname}</a>
-              </li>
-            ))
-          )}
-        </ul>
-      ) : null}
-    </div>
+
+      <dialog
+        ref={dialogRef}
+        className="bundle-search-dialog"
+        onClose={() => setIsOpen(false)}
+        onClick={(e) => {
+          if (e.target === dialogRef.current) setIsOpen(false);
+        }}
+      >
+        <div className="bundle-search-dialog-inner">
+          <input
+            autoFocus
+            type="search"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder={`Search ${qualnames.length} symbols in ${pkg}…`}
+            className="bundle-search-dialog-input"
+            aria-label="Search API symbols"
+            aria-controls="bundle-search-results"
+            aria-activedescendant={selectedIndex >= 0 ? `search-hit-${selectedIndex}` : undefined}
+          />
+          <ul id="bundle-search-results" className="bundle-search-dialog-results" role="listbox">
+            {query.trim() === "" ? (
+              <li className="bundle-search-empty">Type to search…</li>
+            ) : hits.length === 0 ? (
+              <li className="bundle-search-empty">No matches</li>
+            ) : (
+              hits.map((h, index) => {
+                const label = qualnameLabel(h.qualname);
+                const mod = qualnameParent(h.qualname);
+                const isSelected = index === selectedIndex;
+                return (
+                  <li
+                    key={h.qualname}
+                    id={`search-hit-${index}`}
+                    role="option"
+                    aria-selected={isSelected}
+                    ref={(el) => {
+                      itemRefs.current[index] = el;
+                    }}
+                  >
+                    <a
+                      href={linkForQualname(pkg, ver, h.qualname)}
+                      onClick={() => setIsOpen(false)}
+                      tabIndex={-1}
+                    >
+                      <span className="search-hit-label">{label}</span>
+                      <span className="search-hit-module">{mod ?? h.qualname}</span>
+                    </a>
+                  </li>
+                );
+              })
+            )}
+          </ul>
+        </div>
+      </dialog>
+    </>
   );
 }

--- a/viewer/src/lib/search.ts
+++ b/viewer/src/lib/search.ts
@@ -18,7 +18,7 @@ export interface SearchHit {
 export function filterQualnames(
   qualnames: readonly string[],
   query: string,
-  limit = 50
+  limit = 100
 ): SearchHit[] {
   const q = query.trim().toLowerCase();
   if (q === "") return [];

--- a/viewer/src/styles/global.css
+++ b/viewer/src/styles/global.css
@@ -733,58 +733,11 @@ section.backrefs ul.qualnames {
   outline-offset: 2px;
 }
 
-/* Bundle search island. Stays above the qualname list; results overlay
-   visually by separating the block with a border-top. */
-.bundle-search {
-  margin: 0 0 1.5rem;
-}
-.bundle-search-input {
-  width: 100%;
-  padding: 0.5rem 0.75rem;
-  font-family: var(--mono);
-  font-size: 0.9rem;
-  background: var(--surface);
-  color: var(--fg);
-  border: 1px solid var(--border);
-  border-radius: 4px;
-}
-.bundle-search-input:focus {
-  outline: none;
-  border-color: var(--accent);
-}
-.bundle-search-input:disabled {
-  color: var(--fg-muted);
-  background: var(--surface-alt);
-}
+/* Bundle search error message (shown in sidebar if index fails to load) */
 .bundle-search-error {
   color: var(--math-error-fg);
   font-size: 0.85rem;
   margin: 0.25rem 0 0;
-}
-.bundle-search-results {
-  list-style: none;
-  padding: 0;
-  margin: 0.5rem 0 0;
-  border-top: 1px solid var(--border);
-  font-family: var(--mono);
-  font-size: 0.85rem;
-  max-height: 20rem;
-  overflow-y: auto;
-}
-.bundle-search-results li {
-  padding: 0.25rem 0;
-  border-bottom: 1px solid var(--border);
-}
-.bundle-search-results a {
-  color: var(--accent);
-  text-decoration: none;
-}
-.bundle-search-results a:hover {
-  text-decoration: underline;
-}
-.bundle-search-empty {
-  color: var(--fg-muted);
-  font-style: italic;
 }
 
 /* ---------------------------------------------------------------------------
@@ -895,13 +848,131 @@ section.backrefs ul.qualnames {
   min-height: 0;
 }
 
-/* Tighten the bundle-search padding inside the narrower sidebar */
-.sidebar-api .bundle-search {
-  margin-bottom: 0.75rem;
-}
-.sidebar-api .bundle-search-input {
+/* Sidebar search trigger — styled button that looks like a read-only input */
+.bundle-search-trigger {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  width: 100%;
   padding: 0.35rem 0.5rem;
+  font-family: var(--mono);
   font-size: 0.8rem;
+  background: var(--surface);
+  color: var(--fg-muted);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  cursor: pointer;
+  text-align: left;
+  margin-bottom: 0.75rem;
+  transition:
+    border-color 0.1s,
+    color 0.1s;
+}
+.bundle-search-trigger:hover:not(:disabled) {
+  border-color: var(--accent);
+  color: var(--fg);
+}
+.bundle-search-trigger:disabled {
+  cursor: default;
+  opacity: 0.6;
+}
+.bundle-search-trigger-icon {
+  font-size: 1rem;
+  line-height: 1;
+  flex-shrink: 0;
+}
+.bundle-search-trigger-text {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Dialog overlay */
+.bundle-search-dialog {
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--surface);
+  color: var(--fg);
+  padding: 0;
+  width: min(560px, 90vw);
+  max-height: 70vh;
+  top: 10vh;
+  margin: 0 auto;
+  box-shadow: 0 8px 40px rgba(0, 0, 0, 0.25);
+  overflow: hidden;
+}
+.bundle-search-dialog::backdrop {
+  background: rgba(0, 0, 0, 0.35);
+}
+.bundle-search-dialog-inner {
+  display: flex;
+  flex-direction: column;
+}
+.bundle-search-dialog-input {
+  width: 100%;
+  padding: 0.85rem 1rem;
+  font-family: var(--mono);
+  font-size: 1rem;
+  background: transparent;
+  color: var(--fg);
+  border: none;
+  border-bottom: 1px solid var(--border);
+  outline: none;
+  flex-shrink: 0;
+}
+.bundle-search-dialog-results {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  overflow-y: auto;
+  max-height: calc(70vh - 3.5rem);
+}
+.bundle-search-dialog-results li {
+  border-bottom: 1px solid var(--border);
+}
+.bundle-search-dialog-results li:last-child {
+  border-bottom: none;
+}
+.bundle-search-dialog-results a {
+  display: block;
+  padding: 0.45rem 1rem;
+  text-decoration: none;
+  color: var(--fg);
+}
+.bundle-search-dialog-results a:hover {
+  background: var(--surface-alt);
+}
+.bundle-search-dialog-results .bundle-search-empty {
+  padding: 0.75rem 1rem;
+  color: var(--fg-muted);
+  font-style: italic;
+  font-family: var(--mono);
+  font-size: 0.85rem;
+}
+
+/* Two-line result item */
+.search-hit-label {
+  display: block;
+  font-family: var(--mono);
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--accent);
+}
+.search-hit-module {
+  display: block;
+  font-family: var(--mono);
+  font-size: 0.75rem;
+  color: var(--fg-muted);
+}
+
+/* Keyboard-selected result */
+.bundle-search-dialog-results li[aria-selected="true"] > a {
+  background: var(--surface-alt);
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+}
+.bundle-search-dialog-results li[aria-selected="true"] .search-hit-label {
+  color: var(--fg);
 }
 
 /* Base styles for sidebar list variants. Each variant overrides font, sizing,


### PR DESCRIPTION
See each commits. It should fix the deploy, and allow `papyri upload --to <preconfigured server>` instead of jugging with tokens.